### PR TITLE
feat: wire complete LangGraph StateGraph + SSE streaming (#15)

### DIFF
--- a/agent/graph.py
+++ b/agent/graph.py
@@ -1,8 +1,16 @@
+from typing import Annotated
+
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import END, Send, StateGraph
+from langgraph.graph import END, StateGraph
 
 from .nodes.code_generator import code_generator
-from .nodes.decision_gate import conditional_review, decision_gate, feedback_generator
+from .nodes.decision_gate import (
+    conditional_review,
+    decision_gate,
+    feedback_generator,
+    route_conditional,
+    route_decision,
+)
 from .nodes.deployer import deployer
 from .nodes.doc_generator import doc_generator
 from .nodes.input_processor import input_processor
@@ -17,9 +25,19 @@ from .nodes.vibe_council import (
 from .state import VibeDeployState
 
 
+def merge_dicts(left: dict | None, right: dict | None) -> dict:
+    merged = dict(left or {})
+    merged.update(right or {})
+    return merged
+
+
+class PipelineState(VibeDeployState, total=False):
+    council_analysis: Annotated[dict | None, merge_dicts]
+    scoring: Annotated[dict | None, merge_dicts]
+
+
 def create_graph():
-    workflow = StateGraph(VibeDeployState)
-    # Add nodes (stubs imported from nodes/)
+    workflow = StateGraph(PipelineState)
     workflow.add_node("input_processor", input_processor)
     workflow.add_node("run_council_agent", run_council_agent)
     workflow.add_node("cross_examination", cross_examination)
@@ -31,14 +49,42 @@ def create_graph():
     workflow.add_node("doc_generator", doc_generator)
     workflow.add_node("code_generator", code_generator)
     workflow.add_node("deployer", deployer)
-
-    # Entry
     workflow.set_entry_point("input_processor")
-    # TODO: Wire edges (will be completed in issue #15)
-    workflow.add_edge("input_processor", "run_council_agent")  # Simplified for now
-    workflow.add_edge("run_council_agent", END)
+    workflow.add_conditional_edges(
+        "input_processor",
+        fan_out_analysis,
+        ["run_council_agent"],
+    )
+    workflow.add_edge("run_council_agent", "cross_examination")
+    workflow.add_conditional_edges(
+        "cross_examination",
+        fan_out_scoring,
+        ["score_axis"],
+    )
+    workflow.add_edge("score_axis", "strategist_verdict")
+    workflow.add_edge("strategist_verdict", "decision_gate")
+    workflow.add_conditional_edges(
+        "decision_gate",
+        route_decision,
+        {
+            "doc_generator": "doc_generator",
+            "conditional_review": "conditional_review",
+            "feedback_generator": "feedback_generator",
+        },
+    )
+    workflow.add_conditional_edges(
+        "conditional_review",
+        route_conditional,
+        {
+            "doc_generator": "doc_generator",
+            "feedback_generator": "feedback_generator",
+        },
+    )
+    workflow.add_edge("doc_generator", "code_generator")
+    workflow.add_edge("code_generator", "deployer")
+    workflow.add_edge("deployer", END)
+    workflow.add_edge("feedback_generator", END)
 
-    _ = (Send, fan_out_analysis, fan_out_scoring, decision_gate)
     return workflow.compile(checkpointer=MemorySaver())
 
 

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,20 +1,169 @@
 import json
+import traceback
 
 from gradient_adk import RequestContext, entrypoint
+
+from .graph import app
 
 
 @entrypoint
 async def main(input: dict, context: RequestContext):
-    """vibeDeploy agent entrypoint — SSE streaming"""
     prompt = input.get("prompt", "")
-    config = input.get("config", {})
-    thread_id = config.get("configurable", {}).get("thread_id", "default")
-
-    _ = (prompt, thread_id, context)
+    config_data = input.get("config", {})
+    thread_id = config_data.get("configurable", {}).get("thread_id", "default")
+    config = {"configurable": {"thread_id": thread_id}}
+    _ = context
 
     async def stream():
-        yield f"event: council.phase.start\ndata: {json.dumps({'phase': 'starting', 'message': 'vibeDeploy starting...'})}\n\n"
-        # TODO: Wire to graph execution
-        yield f"event: council.phase.start\ndata: {json.dumps({'phase': 'complete', 'message': 'Pipeline complete'})}\n\n"
+        yield _sse(
+            "council.phase.start",
+            {
+                "type": "council.phase.start",
+                "phase": "input_processing",
+                "message": "Processing your idea...",
+            },
+        )
+
+        try:
+            async for event in app.astream_events(
+                {"raw_input": prompt},
+                config=config,
+                version="v2",
+            ):
+                kind = event.get("event", "")
+                name = event.get("name", "")
+                data = event.get("data", {})
+
+                if kind == "on_chain_start" and name in _NODE_EVENTS:
+                    node_event = _NODE_EVENTS[name]
+                    yield _sse(
+                        "council.node.start",
+                        {
+                            "type": "council.node.start",
+                            "node": name,
+                            "phase": node_event["phase"],
+                            "message": node_event["message"],
+                        },
+                    )
+                    continue
+
+                if kind != "on_chain_end" or name not in _NODE_EVENTS:
+                    continue
+
+                output = data.get("output", {})
+                phase = output.get("phase", _NODE_EVENTS[name]["phase"])
+                yield _sse(
+                    "council.node.complete",
+                    {
+                        "type": "council.node.complete",
+                        "node": name,
+                        "phase": phase,
+                        "message": f"{name} complete",
+                    },
+                )
+
+                if name == "run_council_agent":
+                    analyses = output.get("council_analysis", {}) or {}
+                    for agent_name, analysis in analyses.items():
+                        yield _sse(
+                            "council.agent.analysis",
+                            {
+                                "type": "council.agent.analysis",
+                                "agent": agent_name,
+                                "score": analysis.get("score", 0),
+                                "findings_count": len(analysis.get("findings", [])),
+                            },
+                        )
+                elif name == "strategist_verdict":
+                    scoring = output.get("scoring", {}) or {}
+                    yield _sse(
+                        "council.verdict",
+                        {
+                            "type": "council.verdict",
+                            "final_score": scoring.get("final_score", 0),
+                            "decision": scoring.get("decision", "NO_GO"),
+                        },
+                    )
+                elif name == "deployer":
+                    deploy = output.get("deploy_result", {}) or {}
+                    yield _sse(
+                        "deploy.complete",
+                        {
+                            "type": "deploy.complete",
+                            "live_url": deploy.get("live_url", ""),
+                            "github_repo": deploy.get("github_repo", ""),
+                            "status": deploy.get("status", ""),
+                        },
+                    )
+
+            yield _sse(
+                "council.phase.complete",
+                {
+                    "type": "council.phase.complete",
+                    "phase": "complete",
+                    "message": "Pipeline complete",
+                },
+            )
+        except Exception as exc:
+            yield _sse(
+                "council.error",
+                {
+                    "type": "council.error",
+                    "error": str(exc)[:500],
+                    "traceback": traceback.format_exc()[:1000],
+                },
+            )
 
     return stream()
+
+
+def _sse(event_type: str, data: dict) -> str:
+    return f"event: {event_type}\ndata: {json.dumps(data, ensure_ascii=False)}\n\n"
+
+
+_NODE_EVENTS = {
+    "input_processor": {
+        "phase": "input_processing",
+        "message": "Analyzing your idea...",
+    },
+    "run_council_agent": {
+        "phase": "individual_analysis",
+        "message": "Council members analyzing...",
+    },
+    "cross_examination": {
+        "phase": "cross_examination",
+        "message": "Council members debating...",
+    },
+    "score_axis": {
+        "phase": "scoring",
+        "message": "Scoring axes...",
+    },
+    "strategist_verdict": {
+        "phase": "verdict",
+        "message": "Strategist delivering verdict...",
+    },
+    "decision_gate": {
+        "phase": "decision",
+        "message": "Making decision...",
+    },
+    "doc_generator": {
+        "phase": "doc_generation",
+        "message": "Generating documentation...",
+    },
+    "code_generator": {
+        "phase": "code_generation",
+        "message": "Generating code...",
+    },
+    "deployer": {
+        "phase": "deployment",
+        "message": "Deploying to DigitalOcean...",
+    },
+    "feedback_generator": {
+        "phase": "feedback",
+        "message": "Generating feedback...",
+    },
+    "conditional_review": {
+        "phase": "conditional_review",
+        "message": "Waiting for your decision...",
+    },
+}


### PR DESCRIPTION
## Summary
- Wire the complete LangGraph pipeline graph with all nodes, edges, fan-out/fan-in, and conditional routing
- Replace stub SSE streaming with real `astream_events` from graph execution

## Pipeline Flow
```
input_processor
    ↓ (fan-out × 5)
run_council_agent [parallel]
    ↓ (fan-in)
cross_examination
    ↓ (fan-out × 5)
score_axis [parallel]
    ↓ (fan-in)
strategist_verdict
    ↓
decision_gate
    ↓
┌─────────────┬──────────────────┬──────────────────┐
│ GO          │ CONDITIONAL      │ NO-GO            │
│ doc_gen     │ conditional_rev  │ feedback_gen     │
│ code_gen    │ → doc/feedback   │ → END            │
│ deployer    │                  │                  │
│ → END       │                  │                  │
└─────────────┴──────────────────┴──────────────────┘
```

## Key Technical Decisions
- `PipelineState` extends `VibeDeployState` with custom `merge_dicts` reducers for `council_analysis` and `scoring` fields
- Fan-out via `add_conditional_edges` + `Send` API for true parallel execution
- Fan-in is automatic — LangGraph waits for all `Send` executions to complete
- `MemorySaver` checkpointer enables `interrupt()`/`resume` for CONDITIONAL path

## SSE Events Emitted
| Event | When |
|-------|------|
| `council.phase.start` | Pipeline begins |
| `council.node.start/complete` | Each node starts/finishes |
| `council.agent.analysis` | Per-agent analysis results |
| `council.verdict` | Final score + decision |
| `deploy.complete` | Deployment result with live URL |
| `council.error` | Pipeline errors |
| `council.phase.complete` | Pipeline done |

Closes #15