### PR TITLE
feat(#53): Gemini 공식 SDK Adapter — 3 canonical models + tests

### DIFF
--- a/agent/providers/google_adapter.py
+++ b/agent/providers/google_adapter.py
@@ -30,6 +30,8 @@ class GoogleAdapter:
         import google.genai as genai
 
         api_key = os.environ.get("GEMINI_API_KEY", "") or os.environ.get("GOOGLE_API_KEY", "")
+        if not api_key:
+            raise ValueError("GEMINI_API_KEY or GOOGLE_API_KEY environment variable is required")
         return genai.Client(api_key=api_key)
 
     async def generate_content(

--- a/agent/providers/registry.py
+++ b/agent/providers/registry.py
@@ -81,6 +81,14 @@ CAPABILITY_REGISTRY: dict[str, ProviderModelSpec] = {
         "max_context_tokens": 1_000_000,
         "max_output_tokens": 65_536,
     },
+    "gemini-3.1-pro-preview-customtools": {
+        "provider": "google",
+        "model_id": "gemini-3.1-pro-preview-customtools",
+        "api_style": "google_generate_content",
+        "supports_tools": True,
+        "max_context_tokens": 1_000_000,
+        "max_output_tokens": 65_536,
+    },
     "gemini-3.1-flash-lite-preview": {
         "provider": "google",
         "model_id": "gemini-3.1-flash-lite-preview",

--- a/agent/tests/test_google_adapter.py
+++ b/agent/tests/test_google_adapter.py
@@ -1,0 +1,77 @@
+"""Tests for Google Gemini adapter (issue #53)."""
+
+import pytest
+
+from agent.providers.google_adapter import GoogleAdapter
+from agent.providers.registry import CAPABILITY_REGISTRY, resolve_canonical
+
+
+def test_google_adapter_provider_name():
+    adapter = GoogleAdapter()
+    assert adapter.provider_name == "google"
+
+
+def test_google_adapter_raises_for_langchain():
+    adapter = GoogleAdapter()
+    with pytest.raises(NotImplementedError, match="does not use LangChain"):
+        adapter.create_langchain_llm("gemini-3.1-pro-preview", temperature=0.5, max_tokens=4000, timeout=60.0)
+
+
+def test_google_adapter_get_client_requires_api_key(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    adapter = GoogleAdapter()
+    with pytest.raises(ValueError, match="GEMINI_API_KEY"):
+        adapter.get_client()
+
+
+def test_google_adapter_get_client_uses_gemini_key(monkeypatch):
+    monkeypatch.setenv("GEMINI_API_KEY", "test-gemini-key")
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    adapter = GoogleAdapter()
+    client = adapter.get_client()
+    assert client is not None
+
+
+def test_google_adapter_get_client_uses_google_key_fallback(monkeypatch):
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-google-key")
+    adapter = GoogleAdapter()
+    client = adapter.get_client()
+    assert client is not None
+
+
+def test_canonical_gemini_models_in_registry():
+    required = {
+        "gemini-3.1-pro-preview",
+        "gemini-3.1-pro-preview-customtools",
+        "gemini-3.1-flash-lite-preview",
+    }
+    assert required <= set(CAPABILITY_REGISTRY.keys())
+
+
+def test_all_gemini_models_route_to_google():
+    for model_id, spec in CAPABILITY_REGISTRY.items():
+        if "gemini" in model_id:
+            assert spec["provider"] == "google"
+            assert spec["api_style"] == "google_generate_content"
+
+
+def test_legacy_gemini_alias_resolves():
+    assert resolve_canonical("google-gemini-3.1-pro") == "gemini-3.1-pro-preview"
+    assert resolve_canonical("google-gemini-3.1-flash-lite-preview") == "gemini-3.1-flash-lite-preview"
+
+
+def test_canonical_gemini_id_is_identity():
+    assert resolve_canonical("gemini-3.1-pro-preview") == "gemini-3.1-pro-preview"
+    assert resolve_canonical("gemini-3.1-flash-lite-preview") == "gemini-3.1-flash-lite-preview"
+
+
+def test_flash_lite_does_not_support_tools():
+    spec = CAPABILITY_REGISTRY["gemini-3.1-flash-lite-preview"]
+    assert spec["supports_tools"] is False
+
+
+def test_pro_preview_supports_tools():
+    spec = CAPABILITY_REGISTRY["gemini-3.1-pro-preview"]
+    assert spec["supports_tools"] is True

--- a/agent/tests/test_provider_registry.py
+++ b/agent/tests/test_provider_registry.py
@@ -85,6 +85,7 @@ def test_all_doc17_models_in_registry():
         "claude-sonnet-4-6",
         "claude-opus-4-6",
         "gemini-3.1-pro-preview",
+        "gemini-3.1-pro-preview-customtools",
         "gemini-3.1-flash-lite-preview",
     }
     assert required == set(CAPABILITY_REGISTRY.keys())


### PR DESCRIPTION
## Summary
- `gemini-3.1-pro-preview-customtools` 모델 CAPABILITY_REGISTRY에 추가
- `GoogleAdapter.get_client()` API 키 검증 강화
- 전용 테스트 파일 11개 테스트 추가

## Issue
Closes #53

## Local CI
- [x] ruff check passed
- [x] ruff format passed
- [x] test_google_adapter: 11/11 passed
- [x] test_provider_registry: 12/12 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)