### PR TITLE
fix(scoring): coerce LLM score types to int and default missing risk to 100

### DIFF
--- a/agent/nodes/vibe_council.py
+++ b/agent/nodes/vibe_council.py
@@ -14,14 +14,16 @@ logger = logging.getLogger(__name__)
 _COUNCIL_LLM_TIMEOUT_SECONDS = 180
 
 
-def _safe_score(value: object, default: int = 0) -> int:
-    """Coerce an LLM-produced score to int, clamped to [0, 100].
+def _safe_score(value: object, default: int = 0, *, clamp: bool = True) -> int:
+    """Coerce an LLM-produced score to int.
 
     LLM responses may return scores as strings (``"85"``), floats, or
     other unexpected types.  This helper guarantees a usable integer.
+    When *clamp* is True (default), the result is clamped to [0, 100].
     """
     try:
-        return max(0, min(100, int(float(value))))
+        result = int(float(value))
+        return max(0, min(100, result)) if clamp else result
     except (TypeError, ValueError):
         return default
 
@@ -258,11 +260,7 @@ async def score_axis(input: dict) -> dict:
         if isinstance(debate, dict):
             score_adjustments = debate.get("score_adjustments", {})
             if isinstance(score_adjustments, dict):
-                raw_adj = score_adjustments.get(agent_name, 0)
-                try:
-                    adjustment += int(float(raw_adj))
-                except (TypeError, ValueError):
-                    pass
+                adjustment += _safe_score(score_adjustments.get(agent_name, 0), clamp=False)
 
     adjustment = max(-10, adjustment)
     final_score = max(0, min(100, base_score + adjustment))


### PR DESCRIPTION
## Summary

- Add `_safe_score()` helper to coerce LLM-produced score values (strings, floats) to clamped `int` in `[0, 100]`
- Fix `risk_profile` default from `0` to `100` — the Vibe Score formula uses `(100 - risk)`, so missing risk should assume maximum risk
- Apply type coercion to `score_axis()` base scores + cross-exam adjustments, and all 5 axes in `strategist_verdict()`

## Problem

LLM responses can return scores as strings (`"85"`) or floats (`85.0`), causing `TypeError` in arithmetic. The risk default of `0` with the inverted formula `(100 - 0) * 0.20 = 20` gives missing risk data a perfect safety score, artificially inflating Vibe Scores.

## Changes

`agent/nodes/vibe_council.py`:
- New `_safe_score(value, default)` → `int(float(value))` clamped to `[0, 100]`
- `score_axis`: `base_score` and cross-exam `adjustment` now coerced via `_safe_score` / `int(float())`
- `strategist_verdict`: all 5 axis lookups wrapped in `_safe_score()`
- Risk default: `0` → `100`

## Validation

- `ruff check` + `ruff format --check`: clean
- 33/33 scoring-related tests pass (0 failures)

Addresses review feedback from PR #30 (P1: score type coercion, P2: risk default)