### PR TITLE
refactor(cost): deduplicate pricing entries — single source per model

### DIFF
--- a/agent/cost.py
+++ b/agent/cost.py
@@ -43,11 +43,8 @@ PRICING_PER_MILLION = {
 
 
 def _resolve_price(model: str) -> tuple[float, float]:
-    price = PRICING_PER_MILLION.get(model)
-    if price is not None:
-        return price
     canonical = LEGACY_MODEL_ALIASES.get(model, model)
-    return PRICING_PER_MILLION.get(canonical, (0.0, 0.0))
+    return PRICING_PER_MILLION.get(canonical, PRICING_PER_MILLION.get(model, (0.0, 0.0)))
 
 
 DB_MONTHLY_COST = 15.15


### PR DESCRIPTION
## Summary

- Remove 4 duplicate DO-prefixed pricing entries that duplicated canonical model prices
- Add `_resolve_price()` helper that falls back through `LEGACY_MODEL_ALIASES`
- `CostTracker.record()` now resolves aliases before price lookup

## Problem

Same model had two pricing entries under different names (e.g. `openai-gpt-5.2` and `gpt-5.2` both at `(1.75, 14.00)`). Updating price in one place but not the other would cause silent cost tracking errors.

## Removed duplicates

| Removed (DO-prefixed) | Kept (canonical) | Price |
|---|---|---|
| `openai-gpt-5.2` | `gpt-5.2` | (1.75, 14.00) |
| `openai-gpt-5.3-codex` | `gpt-5.3-codex` | (1.75, 14.00) |
| `anthropic-claude-4.6-sonnet` | `claude-sonnet-4-6` | (3.00, 15.00) |
| `anthropic-claude-opus-4.6` | `claude-opus-4-6` | (5.00, 25.00) |

## Validation

- `ruff check` + `ruff format --check`: clean
- Manual verification: all 7 alias resolutions produce correct prices
- `CostTracker.record("anthropic-claude-4.6-sonnet", ...)` correctly resolves to canonical pricing

Addresses review feedback from PR #85 (duplicate cost entries)