### PR TITLE
refactor(DRY): replace duplicated _parse_json_response with shared utility

### DIFF
--- a/agent/nodes/doc_generator.py
+++ b/agent/nodes/doc_generator.py
@@ -3,7 +3,7 @@ import re
 
 import yaml
 
-from ..llm import MODEL_CONFIG, ainvoke_with_retry, get_llm, get_rate_limit_fallback_models
+from ..llm import MODEL_CONFIG, ainvoke_with_retry, content_to_str, get_llm, get_rate_limit_fallback_models
 from ..prompts.doc_templates import (
     API_SPEC_SYSTEM_PROMPT,
     APP_SPEC_SYSTEM_PROMPT,
@@ -14,6 +14,7 @@ from ..prompts.doc_templates import (
 )
 from ..state import VibeDeployState
 from ..tools.digitalocean import build_app_spec
+from ..utils.json_utils import parse_json_response
 
 
 async def doc_generator(state: VibeDeployState) -> dict:
@@ -141,7 +142,7 @@ async def _generate_markdown_doc(
             ],
             fallback_models=fallback_models,
         )
-        parsed = _parse_json_response(response.content, {"content": ""})
+        parsed = parse_json_response(content_to_str(response.content), {"content": ""})
         content = parsed.get("content", "")
         if isinstance(content, str) and content.strip():
             return content
@@ -179,7 +180,7 @@ async def _generate_app_spec_yaml_doc(llm, context: str, idea: dict, fallback_mo
             ],
             fallback_models=fallback_models,
         )
-        parsed = _parse_json_response(response.content, {"content": ""})
+        parsed = parse_json_response(content_to_str(response.content), {"content": ""})
         content = parsed.get("content", "")
         if isinstance(content, str) and content.strip():
             return content
@@ -236,26 +237,3 @@ def _slugify(value: str) -> str:
     clean = re.sub(r"[\s_]+", "-", clean)
     clean = re.sub(r"-+", "-", clean)
     return clean or "vibedeploy-app"
-
-
-def _parse_json_response(content, default: dict) -> dict:
-    from ..llm import content_to_str
-
-    content = content_to_str(content).strip()
-    if content.startswith("```"):
-        content = re.sub(r"^```(?:json)?\n?", "", content)
-        content = re.sub(r"\n?```$", "", content)
-
-    try:
-        return json.loads(content)
-    except json.JSONDecodeError:
-        json_match = re.search(r"\{[\s\S]*\}", content)
-        if json_match:
-            try:
-                return json.loads(json_match.group())
-            except json.JSONDecodeError:
-                pass
-
-        result = dict(default)
-        result["raw_response"] = content[:500]
-        return result

--- a/agent/nodes/vibe_council.py
+++ b/agent/nodes/vibe_council.py
@@ -1,8 +1,6 @@
 import asyncio
-import json
 import logging
 import os
-import re
 
 from langgraph.types import Send
 
@@ -317,29 +315,6 @@ async def strategist_verdict(state: VibeDeployState) -> dict:
         },
         "phase": "verdict_delivered",
     }
-
-
-def _parse_json_response(content, default: dict) -> dict:
-    from ..llm import content_to_str
-
-    content = content_to_str(content).strip()
-    if content.startswith("```"):
-        content = re.sub(r"^```(?:json)?\n?", "", content)
-        content = re.sub(r"\n?```$", "", content)
-
-    try:
-        return json.loads(content)
-    except json.JSONDecodeError:
-        json_match = re.search(r"\{[\s\S]*\}", content)
-        if json_match:
-            try:
-                return json.loads(json_match.group())
-            except json.JSONDecodeError:
-                pass
-
-        result = dict(default)
-        result["raw_response"] = content[:500]
-        return result
 
 
 def _fallback_analysis(agent_name: str, reason: str) -> dict:


### PR DESCRIPTION
## Summary

- Remove dead `_parse_json_response` from `vibe_council.py` (defined but never called)
- Replace `doc_generator.py` local copy with import from `utils.json_utils.parse_json_response`
- Keep `code_generator.py` specialized version (has extra balanced-JSON extraction + detailed logging)
- Remove now-unused `json` and `re` imports from `vibe_council.py`

## Problem

Three files contained nearly identical JSON parsing functions. A shared `parse_json_response` was already created in `agent/utils/json_utils.py` but never wired into the existing copies.

## Changes

- `agent/nodes/vibe_council.py`: remove dead `_parse_json_response` + unused imports
- `agent/nodes/doc_generator.py`: replace local copy with `from ..utils.json_utils import parse_json_response` + `content_to_str()` at call sites

## Validation

- `ruff check` + `ruff format --check`: clean
- 56/56 affected tests pass (doc_generator, vibe_council, code_generator, e2e_evaluate, e2e_brainstorm)

Addresses review feedback from PR #33 and PR #30 (duplicated `_parse_json_response`)