### PR TITLE
feat(agent): add type-safe API client generator (#42)

### DIFF
--- a/agent/nodes/type_generator.py
+++ b/agent/nodes/type_generator.py
@@ -268,7 +268,7 @@ def _build_function_block(
             "  });",
         ]
     else:
-        lines.append(f"  const res = await fetch(`${{API_BASE_URL}}{ts_path}`);")
+        lines.append(f'  const res = await fetch(`${{API_BASE_URL}}{ts_path}`, {{ method: "{method.upper()}" }});')
 
     lines += [
         "  if (!res.ok) throw new ApiError(res.status, await res.text());",

--- a/agent/tests/test_api_client_generator.py
+++ b/agent/tests/test_api_client_generator.py
@@ -108,7 +108,6 @@ def test_includes_api_error_class():
     spec = _make_spec({})
     result = generate_api_client(spec)
     assert "export class ApiError extends Error" in result
-    assert "if (!res.ok) throw new ApiError(res.status, await res.text());" in result or "ApiError" in result
 
 
 def test_includes_api_base_url_from_env():
@@ -188,10 +187,62 @@ def test_path_parameter_is_typed_and_interpolated_in_url():
     )
     result = generate_api_client(spec)
     assert "export async function getUsersById(id: number): Promise<GetUsersByIdResponse>" in result
-    assert "fetch(`${API_BASE_URL}/users/${id}`)" in result
+    assert 'fetch(`${API_BASE_URL}/users/${id}`, { method: "GET" })' in result
 
 
 def test_invalid_json_returns_error_comment():
     result = generate_api_client("{bad json")
+    assert result.startswith("//")
+    assert "Error" in result
+
+
+def test_patch_accepts_typed_body_param_and_json_body():
+    spec = _make_spec(
+        {
+            "/users/{id}": {
+                "patch": {
+                    "parameters": [{"name": "id", "in": "path", "required": True, "schema": {"type": "integer"}}],
+                    "requestBody": {
+                        "required": True,
+                        "content": {"application/json": {"schema": {"$ref": "#/components/schemas/PatchUserRequest"}}},
+                    },
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        }
+    )
+    result = generate_api_client(spec)
+    assert (
+        "export async function patchUsersById(id: number, body: PatchUserRequest): Promise<PatchUsersByIdResponse>"
+        in result
+    )
+    assert 'method: "PATCH"' in result
+    assert "body: JSON.stringify(body)" in result
+
+
+def test_multiple_path_parameters_are_typed_and_interpolated():
+    spec = _make_spec(
+        {
+            "/users/{userId}/posts/{postId}": {
+                "get": {
+                    "parameters": [
+                        {"name": "userId", "in": "path", "required": True, "schema": {"type": "integer"}},
+                        {"name": "postId", "in": "path", "required": True, "schema": {"type": "string"}},
+                    ],
+                    "responses": {"200": {"description": "ok"}},
+                }
+            }
+        }
+    )
+    result = generate_api_client(spec)
+    assert (
+        "export async function getUsersByUseridPostsByPostid(userId: number, postId: string): Promise<GetUsersByUseridPostsByPostidResponse>"
+        in result
+    )
+    assert 'fetch(`${API_BASE_URL}/users/${userId}/posts/${postId}`, { method: "GET" })' in result
+
+
+def test_invalid_spec_structure_returns_error_comment():
+    result = generate_api_client("[]")
     assert result.startswith("//")
     assert "Error" in result


### PR DESCRIPTION
## Summary
- generate typed fetch wrappers from OpenAPI paths
- add ApiError and API_BASE_URL support
- cover request/response typing and function naming

## Issue
Closes #42

## Local Validation
- ruff check passed
- pytest tests/test_api_client_generator.py passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* OpenAPI 사양에서 TypeScript API 클라이언트를 자동으로 생성하는 기능 추가
* 타입이 지정된 요청/응답 매개변수 지원
* 경로 매개변수 처리 및 자동 오류 처리 포함
* 포괄적인 테스트 슈트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->