### PR TITLE
feat(agent): add per-file code generation architecture (#49)

### DIFF
--- a/agent/nodes/per_file_code_generator.py
+++ b/agent/nodes/per_file_code_generator.py
@@ -1,0 +1,252 @@
+import json
+import os
+from pathlib import Path
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class FileSpec(BaseModel):
+    path: str
+    file_type: Literal["page", "component", "api", "route", "service", "config", "style"]
+    description: str
+    dependencies: list[str] = Field(default_factory=list)
+
+
+def extract_file_specs(blueprint: dict) -> list[FileSpec]:
+    if not isinstance(blueprint, dict):
+        return []
+
+    file_specs: list[FileSpec] = []
+    for section in ("frontend_files", "backend_files"):
+        files = blueprint.get(section)
+        if not isinstance(files, dict):
+            continue
+
+        for path, meta in files.items():
+            description = "Generated file"
+            dependencies: list[str] = []
+
+            if isinstance(meta, dict):
+                purpose = meta.get("purpose")
+                if isinstance(purpose, str) and purpose.strip():
+                    description = purpose.strip()
+                imports_from = meta.get("imports_from")
+                if isinstance(imports_from, list):
+                    dependencies = [dep for dep in imports_from if isinstance(dep, str) and dep.strip()]
+            elif isinstance(meta, str) and meta.strip():
+                description = meta.strip()
+
+            file_type = _infer_file_type(path)
+            file_specs.append(
+                FileSpec(
+                    path=str(path),
+                    file_type=file_type,
+                    description=description,
+                    dependencies=dependencies,
+                )
+            )
+
+    return file_specs
+
+
+def generate_single_file(spec: FileSpec, context: dict) -> dict[str, str]:
+    api_contract = context.get("api_contract")
+    design_system = context.get("design_system")
+    already_generated = context.get("already_generated")
+
+    if spec.file_type == "page":
+        content = _page_template(spec.path, spec.description, design_system)
+    elif spec.file_type == "component":
+        content = _component_template(spec.path, spec.description)
+    elif spec.file_type == "api":
+        content = _api_template(spec.path, spec.description, api_contract)
+    elif spec.file_type == "route":
+        content = _route_template(spec.path, spec.description)
+    elif spec.file_type == "service":
+        content = _service_template(spec.path, spec.description)
+    elif spec.file_type == "config":
+        content = _config_template(spec.path, spec.description, design_system)
+    else:
+        content = _style_template(spec.description)
+
+    if isinstance(already_generated, dict):
+        _ = len(already_generated)
+
+    return {spec.path: content}
+
+
+def per_file_code_generator_node(state: dict) -> dict:
+    if not os.getenv("VIBEDEPLOY_USE_PER_FILE_CODEGEN", "").strip():
+        return {}
+
+    blueprint = state.get("blueprint") if isinstance(state, dict) else {}
+    specs = extract_file_specs(blueprint if isinstance(blueprint, dict) else {})
+
+    frontend_manifest = (blueprint or {}).get("frontend_files") if isinstance(blueprint, dict) else {}
+    backend_manifest = (blueprint or {}).get("backend_files") if isinstance(blueprint, dict) else {}
+    frontend_paths = set(frontend_manifest.keys()) if isinstance(frontend_manifest, dict) else set()
+    backend_paths = set(backend_manifest.keys()) if isinstance(backend_manifest, dict) else set()
+
+    frontend_code = dict(state.get("frontend_code") or {})
+    backend_code = dict(state.get("backend_code") or {})
+
+    context = {
+        "api_contract": state.get("api_contract"),
+        "design_system": (blueprint or {}).get("design_system", {}) if isinstance(blueprint, dict) else {},
+        "already_generated": {},
+    }
+
+    for spec in specs:
+        generated = generate_single_file(spec, context)
+        context["already_generated"].update(generated)
+
+        if spec.path in backend_paths:
+            backend_code.update(generated)
+        elif spec.path in frontend_paths:
+            frontend_code.update(generated)
+        elif _is_backend_path(spec.path):
+            backend_code.update(generated)
+        else:
+            frontend_code.update(generated)
+
+    return {
+        "frontend_code": frontend_code,
+        "backend_code": backend_code,
+        "phase": "code_generated",
+    }
+
+
+def _infer_file_type(path: str) -> Literal["page", "component", "api", "route", "service", "config", "style"]:
+    normalized = str(path).replace("\\", "/").lower()
+    file_name = Path(normalized).name
+
+    if file_name in {"page.tsx", "page.jsx"}:
+        return "page"
+    if normalized.endswith(".module.css") or normalized.endswith(".css") or normalized.endswith(".scss"):
+        return "style"
+    if "/components/" in normalized and normalized.endswith((".tsx", ".jsx", ".ts", ".js")):
+        return "component"
+    if file_name in {"routes.py", "route.py"} or "router" in file_name:
+        return "route"
+    if "service" in file_name:
+        return "service"
+    if "api" in file_name or normalized.endswith("src/lib/api.ts") or normalized.endswith("src/lib/api.js"):
+        return "api"
+    if file_name in {
+        "package.json",
+        "requirements.txt",
+        "pyproject.toml",
+        "tsconfig.json",
+        "next.config.js",
+        "next.config.ts",
+    }:
+        return "config"
+
+    if normalized.endswith(".py"):
+        return "service"
+    if normalized.endswith((".tsx", ".jsx", ".ts", ".js")):
+        return "component"
+    return "config"
+
+
+def _to_identifier(path: str) -> str:
+    stem = Path(path).stem
+    parts = [part for part in stem.replace("-", "_").split("_") if part]
+    if not parts:
+        return "Generated"
+    return "".join(part[:1].upper() + part[1:] for part in parts)
+
+
+def _page_template(path: str, description: str, design_system: dict | None) -> str:
+    visual_direction = "product-focused interface"
+    if isinstance(design_system, dict):
+        candidate = design_system.get("visual_direction")
+        if isinstance(candidate, str) and candidate.strip():
+            visual_direction = candidate.strip()
+
+    return (
+        "export default function Page() {\n"
+        "  return (\n"
+        "    <main>\n"
+        f"      <h1>{description}</h1>\n"
+        f"      <p>{visual_direction}</p>\n"
+        "    </main>\n"
+        "  );\n"
+        "}\n"
+    )
+
+
+def _component_template(path: str, description: str) -> str:
+    component_name = _to_identifier(path)
+    return (
+        f"type {component_name}Props = {{\n"
+        "  title?: string;\n"
+        "};\n\n"
+        f'export function {component_name}({{ title = "{description}" }}: {component_name}Props) {{\n'
+        "  return <section>{title}</section>;\n"
+        "}\n\n"
+        f"export default {component_name};\n"
+    )
+
+
+def _api_template(path: str, description: str, api_contract: object) -> str:
+    contract_hint = ""
+    if isinstance(api_contract, str) and api_contract.strip():
+        contract_hint = api_contract.strip().splitlines()[0]
+
+    return (
+        'import { NextResponse } from "next/server";\n\n'
+        "export async function POST(request: Request) {\n"
+        "  const body = await request.json();\n"
+        "  return NextResponse.json({\n"
+        f'    message: "{description}",\n'
+        f'    contract: "{contract_hint}",\n'
+        "    body,\n"
+        "  });\n"
+        "}\n"
+    )
+
+
+def _route_template(path: str, description: str) -> str:
+    return (
+        "from fastapi import APIRouter\n\n"
+        "router = APIRouter()\n\n"
+        '@router.get("/health")\n'
+        "async def health() -> dict[str, str]:\n"
+        f'    return {{"status": "ok", "detail": "{description}"}}\n'
+    )
+
+
+def _service_template(path: str, description: str) -> str:
+    class_name = _to_identifier(path) + "Service"
+    return (
+        f"class {class_name}:\n"
+        f'    """{description}"""\n\n'
+        "    def execute(self) -> dict[str, str]:\n"
+        '        return {"status": "stub"}\n'
+    )
+
+
+def _config_template(path: str, description: str, design_system: dict | None) -> str:
+    normalized = path.lower()
+    if normalized.endswith("package.json"):
+        payload = {"name": "generated-app", "private": True, "description": description}
+        return json.dumps(payload, indent=2)
+    if normalized.endswith("requirements.txt"):
+        return "fastapi\nuvicorn\n"
+    if normalized.endswith((".json", ".toml")):
+        payload = {"description": description}
+        if isinstance(design_system, dict) and design_system.get("typography"):
+            payload["typography"] = str(design_system["typography"])
+        return json.dumps(payload, indent=2)
+    return f'export const config = {{ description: "{description}" }};\n'
+
+
+def _style_template(description: str) -> str:
+    return f'.container {{\n  display: block;\n}}\n\n.title {{\n  content: "{description}";\n}}\n'
+
+
+def _is_backend_path(path: str) -> bool:
+    normalized = path.replace("\\", "/").lower()
+    return normalized.endswith(".py") or normalized == "requirements.txt"

--- a/agent/tests/test_per_file_codegen.py
+++ b/agent/tests/test_per_file_codegen.py
@@ -1,0 +1,169 @@
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from agent.nodes.per_file_code_generator import (
+    FileSpec,
+    extract_file_specs,
+    generate_single_file,
+    per_file_code_generator_node,
+)
+
+
+def _sample_blueprint() -> dict:
+    return {
+        "design_system": {
+            "visual_direction": "editorial control room",
+            "typography": "display serif + mono",
+        },
+        "frontend_files": {
+            "src/app/page.tsx": {"purpose": "main dashboard page", "imports_from": ["src/components/Hero.tsx"]},
+            "src/components/Hero.tsx": {"purpose": "hero component", "imports_from": ["src/lib/api.ts"]},
+            "src/lib/api.ts": {"purpose": "api client", "imports_from": []},
+            "src/app/globals.css": {"purpose": "global styles", "imports_from": []},
+            "package.json": {"purpose": "npm manifest", "imports_from": []},
+        },
+        "backend_files": {
+            "routes.py": {"purpose": "fastapi routes", "imports_from": ["models", "ai_service"]},
+            "ai_service.py": {"purpose": "business logic", "imports_from": []},
+            "requirements.txt": {"purpose": "python deps", "imports_from": []},
+        },
+    }
+
+
+def test_filespec_model_accepts_valid_payload():
+    spec = FileSpec(path="src/app/page.tsx", file_type="page", description="main page", dependencies=["x"])
+    assert spec.path == "src/app/page.tsx"
+    assert spec.file_type == "page"
+    assert spec.dependencies == ["x"]
+
+
+def test_filespec_model_rejects_invalid_file_type():
+    with pytest.raises(ValidationError):
+        FileSpec(path="foo.txt", file_type="unknown", description="x", dependencies=[])
+
+
+def test_extract_file_specs_returns_empty_for_empty_blueprint():
+    assert extract_file_specs({}) == []
+
+
+def test_extract_file_specs_returns_empty_for_non_dict_blueprint():
+    assert extract_file_specs(None) == []
+
+
+def test_extract_file_specs_reads_frontend_and_backend_entries():
+    specs = extract_file_specs(_sample_blueprint())
+    assert len(specs) == 8
+    by_path = {spec.path: spec for spec in specs}
+
+    assert by_path["src/app/page.tsx"].file_type == "page"
+    assert by_path["src/components/Hero.tsx"].file_type == "component"
+    assert by_path["src/lib/api.ts"].file_type == "api"
+    assert by_path["src/app/globals.css"].file_type == "style"
+    assert by_path["package.json"].file_type == "config"
+    assert by_path["routes.py"].file_type == "route"
+    assert by_path["ai_service.py"].file_type == "service"
+    assert by_path["requirements.txt"].file_type == "config"
+
+
+def test_extract_file_specs_uses_defaults_for_string_metadata():
+    blueprint = {
+        "frontend_files": {"src/components/Box.tsx": "box component"},
+        "backend_files": {},
+    }
+    specs = extract_file_specs(blueprint)
+    assert specs[0].description == "box component"
+    assert specs[0].dependencies == []
+
+
+def test_generate_single_file_page_template_contains_next_page_shape():
+    spec = FileSpec(path="src/app/page.tsx", file_type="page", description="landing", dependencies=[])
+    result = generate_single_file(spec, {"design_system": {"visual_direction": "studio"}, "already_generated": {}})
+    content = result["src/app/page.tsx"]
+    assert "export default function Page" in content
+    assert "landing" in content
+    assert "studio" in content
+
+
+def test_generate_single_file_component_template_contains_component_name():
+    spec = FileSpec(path="src/components/HeroBanner.tsx", file_type="component", description="hero", dependencies=[])
+    result = generate_single_file(spec, {"already_generated": {}})
+    content = result["src/components/HeroBanner.tsx"]
+    assert "export function HeroBanner" in content
+    assert "export default HeroBanner" in content
+
+
+def test_generate_single_file_api_template_contains_post_handler():
+    spec = FileSpec(path="src/lib/api.ts", file_type="api", description="api client", dependencies=[])
+    result = generate_single_file(spec, {"api_contract": "POST /api/plan", "already_generated": {}})
+    content = result["src/lib/api.ts"]
+    assert "export async function POST" in content
+    assert "NextResponse.json" in content
+    assert "POST /api/plan" in content
+
+
+def test_generate_single_file_route_template_contains_router():
+    spec = FileSpec(path="routes.py", file_type="route", description="routes", dependencies=[])
+    result = generate_single_file(spec, {"already_generated": {}})
+    content = result["routes.py"]
+    assert "APIRouter" in content
+    assert "@router.get" in content
+
+
+def test_generate_single_file_service_template_contains_class():
+    spec = FileSpec(path="ai_service.py", file_type="service", description="svc", dependencies=[])
+    result = generate_single_file(spec, {"already_generated": {}})
+    content = result["ai_service.py"]
+    assert "class AiServiceService" in content
+    assert "def execute" in content
+
+
+def test_generate_single_file_config_template_for_package_json_is_valid_json():
+    spec = FileSpec(path="package.json", file_type="config", description="manifest", dependencies=[])
+    result = generate_single_file(spec, {"already_generated": {}})
+    payload = json.loads(result["package.json"])
+    assert payload["private"] is True
+    assert payload["description"] == "manifest"
+
+
+def test_generate_single_file_style_template_contains_css_blocks():
+    spec = FileSpec(path="src/app/globals.css", file_type="style", description="styles", dependencies=[])
+    result = generate_single_file(spec, {"already_generated": {}})
+    content = result["src/app/globals.css"]
+    assert ".container" in content
+    assert ".title" in content
+
+
+def test_per_file_code_generator_node_returns_empty_when_env_var_disabled(monkeypatch):
+    monkeypatch.delenv("VIBEDEPLOY_USE_PER_FILE_CODEGEN", raising=False)
+    result = per_file_code_generator_node({"blueprint": _sample_blueprint()})
+    assert result == {}
+
+
+def test_per_file_code_generator_node_generates_and_splits_frontend_backend(monkeypatch):
+    monkeypatch.setenv("VIBEDEPLOY_USE_PER_FILE_CODEGEN", "1")
+    state = {
+        "blueprint": _sample_blueprint(),
+        "api_contract": "POST /api/plan",
+        "frontend_code": {"src/existing.ts": "old"},
+        "backend_code": {"existing.py": "old"},
+    }
+
+    result = per_file_code_generator_node(state)
+
+    assert result["phase"] == "code_generated"
+    assert "src/app/page.tsx" in result["frontend_code"]
+    assert "src/components/Hero.tsx" in result["frontend_code"]
+    assert "routes.py" in result["backend_code"]
+    assert "ai_service.py" in result["backend_code"]
+    assert "src/existing.ts" in result["frontend_code"]
+    assert "existing.py" in result["backend_code"]
+
+
+def test_per_file_code_generator_node_handles_empty_blueprint_when_enabled(monkeypatch):
+    monkeypatch.setenv("VIBEDEPLOY_USE_PER_FILE_CODEGEN", "1")
+    result = per_file_code_generator_node({"blueprint": {}})
+    assert result["frontend_code"] == {}
+    assert result["backend_code"] == {}
+    assert result["phase"] == "code_generated"


### PR DESCRIPTION
## Summary
- add env-gated per-file generation node
- support per-file stubs for frontend and backend outputs
- preserve existing generator path when disabled

## Issue
Closes #49

## Local Validation
- ruff check passed
- pytest tests/test_per_file_codegen.py passed
