### PR TITLE
feat(agent): add per-file prompt optimization templates (#52)

### DIFF
--- a/agent/nodes/per_file_prompts.py
+++ b/agent/nodes/per_file_prompts.py
@@ -1,0 +1,125 @@
+from __future__ import annotations
+
+from typing import Any
+
+AVAILABLE_CONTEXT_KEYS = {
+    "design_system",
+    "layout",
+    "navigation",
+    "props_spec",
+    "api_contract",
+    "types",
+    "models",
+}
+
+PROMPT_TEMPLATES: dict[str, dict[str, Any]] = {
+    "page.tsx": {
+        "role": "Senior Next.js page engineer",
+        "context_keys": ["design_system", "layout", "navigation"],
+        "template": (
+            "Role: {role}\n"
+            "File path: {file_path}\n"
+            "Description: {description}\n\n"
+            "Relevant context:\n{context_block}\n"
+            "Task: Build a production-ready Next.js page using App Router patterns, "
+            "accessible semantics, and clear state handling."
+        ),
+        "max_tokens": 4000,
+    },
+    "component.tsx": {
+        "role": "Senior React component engineer",
+        "context_keys": ["design_system", "props_spec"],
+        "template": (
+            "Role: {role}\n"
+            "File path: {file_path}\n"
+            "Description: {description}\n\n"
+            "Relevant context:\n{context_block}\n"
+            "Task: Build a reusable typed component with robust prop ergonomics and "
+            "strict design-system consistency."
+        ),
+        "max_tokens": 3500,
+    },
+    "api.ts": {
+        "role": "Senior TypeScript API client engineer",
+        "context_keys": ["api_contract", "types"],
+        "template": (
+            "Role: {role}\n"
+            "File path: {file_path}\n"
+            "Description: {description}\n\n"
+            "Relevant context:\n{context_block}\n"
+            "Task: Build a typed API client module that follows the contract exactly, "
+            "including request/response typing and safe error paths."
+        ),
+        "max_tokens": 3500,
+    },
+    "routes.py": {
+        "role": "Senior FastAPI routing engineer",
+        "context_keys": ["api_contract", "models"],
+        "template": (
+            "Role: {role}\n"
+            "File path: {file_path}\n"
+            "Description: {description}\n\n"
+            "Relevant context:\n{context_block}\n"
+            "Task: Build FastAPI routes aligned to the contract, model constraints, "
+            "and idiomatic router organization."
+        ),
+        "max_tokens": 4000,
+    },
+    "ai_service.py": {
+        "role": "Senior AI service integration engineer",
+        "context_keys": ["api_contract"],
+        "template": (
+            "Role: {role}\n"
+            "File path: {file_path}\n"
+            "Description: {description}\n\n"
+            "Relevant context:\n{context_block}\n"
+            "Task: Build a minimal AI service implementation that honors the contract "
+            "with clear retry/error boundaries and configurable model access."
+        ),
+        "max_tokens": 3200,
+    },
+}
+
+_GENERIC_TEMPLATE: dict[str, Any] = {
+    "role": "Senior software engineer",
+    "context_keys": [],
+    "template": (
+        "Role: {role}\n"
+        "File path: {file_path}\n"
+        "Description: {description}\n\n"
+        "Relevant context:\n{context_block}\n"
+        "Task: Build production-ready code that matches the requested file purpose."
+    ),
+    "max_tokens": 4000,
+}
+
+
+def get_context_keys_for_type(file_type: str) -> list[str]:
+    template = PROMPT_TEMPLATES.get(file_type, _GENERIC_TEMPLATE)
+    return list(template["context_keys"])
+
+
+def build_prompt(file_type: str, context: dict[str, Any]) -> str:
+    template = PROMPT_TEMPLATES.get(file_type, _GENERIC_TEMPLATE)
+    file_path = str(context.get("file_path", "<unknown-path>"))
+    description = str(context.get("description", "<no-description>"))
+
+    lines: list[str] = []
+    for key in template["context_keys"]:
+        if key in context:
+            value = context[key]
+            if value is not None and value != "":
+                lines.append(f"- {key}: {value}")
+
+    context_block = "\n".join(lines) if lines else "- none"
+
+    return template["template"].format(
+        role=template["role"],
+        file_path=file_path,
+        description=description,
+        context_block=context_block,
+    )
+
+
+def estimate_tokens(prompt: str) -> int:
+    return len(prompt) // 4

--- a/agent/tests/test_per_file_prompts.py
+++ b/agent/tests/test_per_file_prompts.py
@@ -1,0 +1,123 @@
+from agent.nodes.per_file_prompts import (
+    AVAILABLE_CONTEXT_KEYS,
+    PROMPT_TEMPLATES,
+    build_prompt,
+    estimate_tokens,
+    get_context_keys_for_type,
+)
+
+
+def test_all_required_file_types_have_templates():
+    assert "page.tsx" in PROMPT_TEMPLATES
+    assert "component.tsx" in PROMPT_TEMPLATES
+    assert "api.ts" in PROMPT_TEMPLATES
+    assert "routes.py" in PROMPT_TEMPLATES
+    assert "ai_service.py" in PROMPT_TEMPLATES
+
+
+def test_template_config_has_required_fields_and_types():
+    for cfg in PROMPT_TEMPLATES.values():
+        assert isinstance(cfg["role"], str)
+        assert isinstance(cfg["context_keys"], list)
+        assert isinstance(cfg["template"], str)
+        assert isinstance(cfg["max_tokens"], int)
+
+
+def test_context_strategy_mappings_match_spec():
+    assert get_context_keys_for_type("page.tsx") == ["design_system", "layout", "navigation"]
+    assert get_context_keys_for_type("component.tsx") == ["design_system", "props_spec"]
+    assert get_context_keys_for_type("api.ts") == ["api_contract", "types"]
+    assert get_context_keys_for_type("routes.py") == ["api_contract", "models"]
+    assert get_context_keys_for_type("ai_service.py") == ["api_contract"]
+
+
+def test_unknown_type_falls_back_to_empty_context_keys():
+    assert get_context_keys_for_type("unknown.ext") == []
+
+
+def test_build_prompt_includes_file_path_and_description():
+    prompt = build_prompt(
+        "api.ts",
+        {
+            "file_path": "web/src/lib/api.ts",
+            "description": "API client for dashboard",
+        },
+    )
+    assert "File path: web/src/lib/api.ts" in prompt
+    assert "Description: API client for dashboard" in prompt
+
+
+def test_build_prompt_filters_irrelevant_context():
+    prompt = build_prompt(
+        "page.tsx",
+        {
+            "file_path": "web/src/app/page.tsx",
+            "description": "Main landing page",
+            "design_system": "high contrast theme",
+            "layout": "hero + cards",
+            "navigation": "top nav",
+            "props_spec": "should not be included",
+        },
+    )
+    assert "- design_system: high contrast theme" in prompt
+    assert "- layout: hero + cards" in prompt
+    assert "- navigation: top nav" in prompt
+    assert "props_spec" not in prompt
+
+
+def test_build_prompt_skips_missing_and_empty_declared_keys():
+    prompt = build_prompt(
+        "component.tsx",
+        {
+            "file_path": "web/src/components/Card.tsx",
+            "description": "Reusable card",
+            "design_system": "tokenized spacing",
+            "props_spec": "",
+        },
+    )
+    assert "- design_system: tokenized spacing" in prompt
+    assert "props_spec" not in prompt
+
+
+def test_empty_context_is_handled():
+    prompt = build_prompt("routes.py", {})
+    assert "File path: <unknown-path>" in prompt
+    assert "Description: <no-description>" in prompt
+    assert "Relevant context:" in prompt
+    assert "- none" in prompt
+
+
+def test_unknown_type_fallback_prompt_is_generic():
+    prompt = build_prompt(
+        "unknown.ext",
+        {
+            "file_path": "x/unknown.ext",
+            "description": "Unknown file",
+            "design_system": "not used",
+        },
+    )
+    assert "Role: Senior software engineer" in prompt
+    assert "File path: x/unknown.ext" in prompt
+    assert "Description: Unknown file" in prompt
+    assert "design_system" not in prompt
+
+
+def test_max_tokens_not_exceed_limit():
+    for cfg in PROMPT_TEMPLATES.values():
+        assert cfg["max_tokens"] <= 8000
+
+
+def test_context_keys_are_subset_of_available_keys():
+    for cfg in PROMPT_TEMPLATES.values():
+        assert set(cfg["context_keys"]).issubset(AVAILABLE_CONTEXT_KEYS)
+
+
+def test_estimate_tokens_returns_int_with_expected_formula():
+    prompt = "a" * 123
+    token_count = estimate_tokens(prompt)
+    assert isinstance(token_count, int)
+    assert token_count == 30
+
+
+def test_estimate_tokens_empty_prompt_returns_zero():
+    assert estimate_tokens("") == 0


### PR DESCRIPTION
## Summary
- add file-type prompt templates and context filtering
- add token estimation and context-key helpers
- keep prompts bounded and deterministic

## Issue
Closes #52

## Local Validation
- ruff check passed
- pytest tests/test_per_file_prompts.py passed
