### PR TITLE
feat(agent): add per-file AST validation and retry flow (#50)

### DIFF
--- a/agent/nodes/per_file_code_generator.py
+++ b/agent/nodes/per_file_code_generator.py
@@ -1,9 +1,19 @@
+import ast
 import json
+import logging
 import os
+import re
 from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+_PYTHON_EXTENSIONS = frozenset({".py"})
+_JS_TS_EXTENSIONS = frozenset({".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"})
+_MAX_RETRY_ATTEMPTS = 3
+_BROKEN_IMPORT_RE = re.compile(r"^\s*import\s+from\s*['\"]", re.MULTILINE)
 
 
 class FileSpec(BaseModel):
@@ -13,7 +23,7 @@ class FileSpec(BaseModel):
     dependencies: list[str] = Field(default_factory=list)
 
 
-def extract_file_specs(blueprint: dict) -> list[FileSpec]:
+def extract_file_specs(blueprint: dict | None) -> list[FileSpec]:
     if not isinstance(blueprint, dict):
         return []
 
@@ -37,11 +47,10 @@ def extract_file_specs(blueprint: dict) -> list[FileSpec]:
             elif isinstance(meta, str) and meta.strip():
                 description = meta.strip()
 
-            file_type = _infer_file_type(path)
             file_specs.append(
                 FileSpec(
                     path=str(path),
-                    file_type=file_type,
+                    file_type=_infer_file_type(str(path)),
                     description=description,
                     dependencies=dependencies,
                 )
@@ -50,10 +59,97 @@ def extract_file_specs(blueprint: dict) -> list[FileSpec]:
     return file_specs
 
 
-def generate_single_file(spec: FileSpec, context: dict) -> dict[str, str]:
+def validate_generated_file(path: str, content: str) -> dict[str, str | bool]:
+    ext = _file_extension(path)
+    if ext in _PYTHON_EXTENSIONS:
+        return _validate_python(content)
+    if ext in _JS_TS_EXTENSIONS:
+        return _validate_js_ts(content)
+    return {"passed": True, "error": ""}
+
+
+def validate_generated_files(files: dict[str, str]) -> dict[str, dict[str, str | bool]]:
+    return {path: validate_generated_file(path, content) for path, content in files.items()}
+
+
+def generate_single_file(spec_or_path, context_or_factory, *, max_retries: int = _MAX_RETRY_ATTEMPTS):
+    if isinstance(spec_or_path, FileSpec) and isinstance(context_or_factory, dict):
+        return _generate_file_from_spec(spec_or_path, context_or_factory)
+    if isinstance(spec_or_path, str) and callable(context_or_factory):
+        return _generate_file_with_validation(spec_or_path, context_or_factory, max_retries=max_retries)
+    raise TypeError("Unsupported generate_single_file arguments")
+
+
+def generate_files_with_validation(files: dict[str, str], *, max_retries: int = _MAX_RETRY_ATTEMPTS) -> dict:
+    final_files: dict[str, str] = {}
+    validation_results: dict[str, dict[str, str | bool]] = {}
+    retry_metadata: dict[str, dict[str, int | bool]] = {}
+
+    for path, content in files.items():
+        initial_result = validate_generated_file(path, content)
+        if initial_result["passed"]:
+            final_files[path] = content
+            validation_results[path] = initial_result
+            retry_metadata[path] = {"attempts": 1, "used_fallback": False}
+            continue
+
+        outcome = _generate_file_with_validation(path, lambda c=content: c, max_retries=max_retries)
+        final_files[path] = outcome["content"]
+        validation_results[path] = outcome["validation"]
+        retry_metadata[path] = {"attempts": outcome["attempts"], "used_fallback": outcome["used_fallback"]}
+
+    return {
+        "files": final_files,
+        "validation_results": validation_results,
+        "retry_metadata": retry_metadata,
+    }
+
+
+def per_file_code_generator_node(state: dict) -> dict:
+    if not os.getenv("VIBEDEPLOY_USE_PER_FILE_CODEGEN", "").strip():
+        return {}
+
+    blueprint = state.get("blueprint") if isinstance(state, dict) else {}
+    blueprint = blueprint if isinstance(blueprint, dict) else {}
+    specs = extract_file_specs(blueprint)
+
+    frontend_manifest = blueprint.get("frontend_files") if isinstance(blueprint.get("frontend_files"), dict) else {}
+    backend_manifest = blueprint.get("backend_files") if isinstance(blueprint.get("backend_files"), dict) else {}
+    frontend_paths = set(frontend_manifest.keys())
+    backend_paths = set(backend_manifest.keys())
+
+    frontend_code = dict(state.get("frontend_code") or {})
+    backend_code = dict(state.get("backend_code") or {})
+
+    context = {
+        "api_contract": state.get("api_contract"),
+        "design_system": blueprint.get("design_system", {}),
+        "already_generated": {},
+    }
+
+    for spec in specs:
+        generated = _generate_file_from_spec(spec, context)
+        context["already_generated"].update(generated)
+
+        if spec.path in backend_paths:
+            backend_code.update(generated)
+        elif spec.path in frontend_paths:
+            frontend_code.update(generated)
+        elif _is_backend_path(spec.path):
+            backend_code.update(generated)
+        else:
+            frontend_code.update(generated)
+
+    return {
+        "frontend_code": frontend_code,
+        "backend_code": backend_code,
+        "phase": "code_generated",
+    }
+
+
+def _generate_file_from_spec(spec: FileSpec, context: dict) -> dict[str, str]:
     api_contract = context.get("api_contract")
     design_system = context.get("design_system")
-    already_generated = context.get("already_generated")
 
     if spec.file_type == "page":
         content = _page_template(spec.path, spec.description, design_system)
@@ -70,50 +166,44 @@ def generate_single_file(spec: FileSpec, context: dict) -> dict[str, str]:
     else:
         content = _style_template(spec.description)
 
-    if isinstance(already_generated, dict):
-        _ = len(already_generated)
-
     return {spec.path: content}
 
 
-def per_file_code_generator_node(state: dict) -> dict:
-    if not os.getenv("VIBEDEPLOY_USE_PER_FILE_CODEGEN", "").strip():
-        return {}
+def _generate_file_with_validation(path: str, content_factory, *, max_retries: int = _MAX_RETRY_ATTEMPTS) -> dict:
+    last_result: dict[str, str | bool] = {"passed": False, "error": "max_retries=0"}
+    content = ""
 
-    blueprint = state.get("blueprint") if isinstance(state, dict) else {}
-    specs = extract_file_specs(blueprint if isinstance(blueprint, dict) else {})
+    for attempt in range(1, max_retries + 1):
+        try:
+            content = content_factory()
+        except Exception as exc:  # noqa: BLE001
+            last_result = {"passed": False, "error": f"content_factory raised: {exc}"}
+            logger.warning("[PER_FILE_CODEGEN] attempt %d/%d factory error for %s: %s", attempt, max_retries, path, exc)
+            continue
 
-    frontend_manifest = (blueprint or {}).get("frontend_files") if isinstance(blueprint, dict) else {}
-    backend_manifest = (blueprint or {}).get("backend_files") if isinstance(blueprint, dict) else {}
-    frontend_paths = set(frontend_manifest.keys()) if isinstance(frontend_manifest, dict) else set()
-    backend_paths = set(backend_manifest.keys()) if isinstance(backend_manifest, dict) else set()
+        result = validate_generated_file(path, content)
+        if result["passed"]:
+            return {
+                "content": content,
+                "validation": result,
+                "attempts": attempt,
+                "used_fallback": False,
+            }
 
-    frontend_code = dict(state.get("frontend_code") or {})
-    backend_code = dict(state.get("backend_code") or {})
-
-    context = {
-        "api_contract": state.get("api_contract"),
-        "design_system": (blueprint or {}).get("design_system", {}) if isinstance(blueprint, dict) else {},
-        "already_generated": {},
-    }
-
-    for spec in specs:
-        generated = generate_single_file(spec, context)
-        context["already_generated"].update(generated)
-
-        if spec.path in backend_paths:
-            backend_code.update(generated)
-        elif spec.path in frontend_paths:
-            frontend_code.update(generated)
-        elif _is_backend_path(spec.path):
-            backend_code.update(generated)
-        else:
-            frontend_code.update(generated)
+        last_result = result
+        logger.warning(
+            "[PER_FILE_CODEGEN] attempt %d/%d validation failed for %s: %s",
+            attempt,
+            max_retries,
+            path,
+            result["error"],
+        )
 
     return {
-        "frontend_code": frontend_code,
-        "backend_code": backend_code,
-        "phase": "code_generated",
+        "content": _fallback_content(path),
+        "validation": last_result,
+        "attempts": max_retries,
+        "used_fallback": True,
     }
 
 
@@ -142,7 +232,6 @@ def _infer_file_type(path: str) -> Literal["page", "component", "api", "route", 
         "next.config.ts",
     }:
         return "config"
-
     if normalized.endswith(".py"):
         return "service"
     if normalized.endswith((".tsx", ".jsx", ".ts", ".js")):
@@ -250,3 +339,138 @@ def _style_template(description: str) -> str:
 def _is_backend_path(path: str) -> bool:
     normalized = path.replace("\\", "/").lower()
     return normalized.endswith(".py") or normalized == "requirements.txt"
+
+
+def _file_extension(path: str) -> str:
+    dot = path.rfind(".")
+    return "" if dot == -1 else path[dot:].lower()
+
+
+def _validate_python(content: str) -> dict[str, str | bool]:
+    if not content.strip():
+        return {"passed": True, "error": ""}
+    try:
+        ast.parse(content)
+        return {"passed": True, "error": ""}
+    except SyntaxError as exc:
+        return {"passed": False, "error": f"SyntaxError: {exc}"}
+
+
+def _validate_js_ts(content: str) -> dict[str, str | bool]:
+    if not content.strip():
+        return {"passed": True, "error": ""}
+    balance_error = _check_bracket_balance(content)
+    if balance_error:
+        return {"passed": False, "error": balance_error}
+    import_error = _check_import_export_basics(content)
+    if import_error:
+        return {"passed": False, "error": import_error}
+    return {"passed": True, "error": ""}
+
+
+def _check_bracket_balance(content: str) -> str:
+    stack: list[str] = []
+    close_to_open = {")": "(", "}": "{", "]": "["}
+    open_chars = frozenset("({[")
+    close_chars = frozenset(")}]")
+
+    in_single_quote = False
+    in_double_quote = False
+    in_template = False
+    in_line_comment = False
+    in_block_comment = False
+
+    i = 0
+    n = len(content)
+    while i < n:
+        ch = content[i]
+
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+            i += 1
+            continue
+
+        if in_block_comment:
+            if ch == "*" and i + 1 < n and content[i + 1] == "/":
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if in_single_quote:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == "'":
+                in_single_quote = False
+            i += 1
+            continue
+
+        if in_double_quote:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == '"':
+                in_double_quote = False
+            i += 1
+            continue
+
+        if in_template:
+            if ch == "\\" and i + 1 < n:
+                i += 2
+                continue
+            if ch == "`":
+                in_template = False
+            i += 1
+            continue
+
+        if ch == "/" and i + 1 < n:
+            if content[i + 1] == "/":
+                in_line_comment = True
+                i += 2
+                continue
+            if content[i + 1] == "*":
+                in_block_comment = True
+                i += 2
+                continue
+
+        if ch == "'":
+            in_single_quote = True
+            i += 1
+            continue
+        if ch == '"':
+            in_double_quote = True
+            i += 1
+            continue
+        if ch == "`":
+            in_template = True
+            i += 1
+            continue
+
+        if ch in open_chars:
+            stack.append(ch)
+        elif ch in close_chars:
+            expected_open = close_to_open[ch]
+            if not stack or stack[-1] != expected_open:
+                return f"Unbalanced bracket: unexpected '{ch}' at position {i}"
+            stack.pop()
+
+        i += 1
+
+    if stack:
+        return f"Unbalanced bracket: unclosed '{stack[-1]}'"
+    return ""
+
+
+def _check_import_export_basics(content: str) -> str:
+    if _BROKEN_IMPORT_RE.search(content):
+        return "Invalid import: missing binding before 'from' (e.g. 'import from \"module\"')"
+    return ""
+
+
+def _fallback_content(path: str) -> str:
+    ext = _file_extension(path)
+    tag = "//" if ext in _JS_TS_EXTENSIONS else "#"
+    return f"{tag} vibedeploy-fallback: validation failed after max retries\n{tag} path: {path}\n"

--- a/agent/tests/test_per_file_ast_validation.py
+++ b/agent/tests/test_per_file_ast_validation.py
@@ -1,0 +1,229 @@
+from agent.nodes.per_file_code_generator import (
+    _MAX_RETRY_ATTEMPTS,
+    generate_files_with_validation,
+    generate_single_file,
+    validate_generated_file,
+    validate_generated_files,
+)
+
+VALID_PYTHON = "def add(a, b):\n    return a + b\n"
+INVALID_PYTHON = "def add(a, b\n    return a + b\n"
+
+VALID_TSX = (
+    'import { useState } from "react";\n'
+    "export default function App() {\n"
+    "  const [count, setCount] = useState(0);\n"
+    "  return <button onClick={() => setCount(count + 1)}>{count}</button>;\n"
+    "}\n"
+)
+
+UNBALANCED_BRACE_TSX = (
+    'import { useState } from "react";\nexport default function App() {\n  return <div>hello</div>;\n'
+)
+
+UNBALANCED_PAREN_TSX = "export default function App( {\n  return <div>hello</div>;\n}\n"
+
+UNBALANCED_BRACKET_TSX = (
+    "const items = [1, 2, 3;\nexport default function App() {\n  return <div>{items.length}</div>;\n}\n"
+)
+
+BROKEN_IMPORT_TSX = 'import from "react";\nexport default function App() { return <div />; }\n'
+
+
+class TestValidatePython:
+    def test_valid_python_passes(self):
+        result = validate_generated_file("main.py", VALID_PYTHON)
+        assert result["passed"] is True
+        assert result["error"] == ""
+
+    def test_invalid_python_fails_with_syntax_error(self):
+        result = validate_generated_file("main.py", INVALID_PYTHON)
+        assert result["passed"] is False
+        assert "SyntaxError" in result["error"]
+
+    def test_empty_python_file_passes(self):
+        result = validate_generated_file("utils.py", "")
+        assert result["passed"] is True
+
+    def test_whitespace_only_python_passes(self):
+        result = validate_generated_file("utils.py", "   \n\n  \t  \n")
+        assert result["passed"] is True
+
+    def test_complex_valid_python_passes(self):
+        code = (
+            "from typing import List\n\n"
+            "class Processor:\n"
+            "    def __init__(self, items: List[str]) -> None:\n"
+            "        self.items = items\n\n"
+            "    def run(self) -> List[str]:\n"
+            "        return [item.upper() for item in self.items]\n"
+        )
+        result = validate_generated_file("processor.py", code)
+        assert result["passed"] is True
+
+
+class TestValidateJsTs:
+    def test_valid_tsx_passes(self):
+        result = validate_generated_file("App.tsx", VALID_TSX)
+        assert result["passed"] is True
+        assert result["error"] == ""
+
+    def test_unbalanced_brace_fails(self):
+        result = validate_generated_file("App.tsx", UNBALANCED_BRACE_TSX)
+        assert result["passed"] is False
+        assert "Unbalanced bracket" in result["error"]
+
+    def test_unbalanced_paren_fails(self):
+        result = validate_generated_file("App.tsx", UNBALANCED_PAREN_TSX)
+        assert result["passed"] is False
+        assert "Unbalanced bracket" in result["error"]
+
+    def test_unbalanced_bracket_fails(self):
+        result = validate_generated_file("page.ts", UNBALANCED_BRACKET_TSX)
+        assert result["passed"] is False
+        assert "Unbalanced bracket" in result["error"]
+
+    def test_broken_import_fails(self):
+        result = validate_generated_file("App.tsx", BROKEN_IMPORT_TSX)
+        assert result["passed"] is False
+        assert "Invalid import" in result["error"]
+
+    def test_empty_ts_file_passes(self):
+        result = validate_generated_file("types.ts", "")
+        assert result["passed"] is True
+
+    def test_valid_js_with_template_literal_passes(self):
+        code = 'const msg = `Hello ${"world"}`;\nconsole.log(msg);\n'
+        result = validate_generated_file("helper.js", code)
+        assert result["passed"] is True
+
+    def test_bracket_inside_string_ignored(self):
+        code = 'const x = "unmatched {";\nexport default function f() { return x; }\n'
+        result = validate_generated_file("util.ts", code)
+        assert result["passed"] is True
+
+    def test_bracket_inside_line_comment_ignored(self):
+        code = "export default function f() {\n  return 1; // closed }\n}\n"
+        result = validate_generated_file("util.ts", code)
+        assert result["passed"] is True
+
+
+class TestUnsupportedExtension:
+    def test_css_file_always_passes(self):
+        result = validate_generated_file("styles.css", "body { color: red")
+        assert result["passed"] is True
+
+    def test_json_file_always_passes(self):
+        result = validate_generated_file("config.json", '{"broken": true')
+        assert result["passed"] is True
+
+    def test_markdown_file_always_passes(self):
+        result = validate_generated_file("README.md", "# Hello")
+        assert result["passed"] is True
+
+
+class TestValidateGeneratedFiles:
+    def test_returns_per_file_map(self):
+        files = {
+            "main.py": VALID_PYTHON,
+            "App.tsx": VALID_TSX,
+            "broken.py": INVALID_PYTHON,
+        }
+        results = validate_generated_files(files)
+        assert set(results.keys()) == {"main.py", "App.tsx", "broken.py"}
+        assert results["main.py"]["passed"] is True
+        assert results["App.tsx"]["passed"] is True
+        assert results["broken.py"]["passed"] is False
+
+    def test_empty_dict_returns_empty_map(self):
+        assert validate_generated_files({}) == {}
+
+
+class TestGenerateSingleFile:
+    def test_passes_on_first_try(self):
+        outcome = generate_single_file("main.py", lambda: VALID_PYTHON)
+        assert outcome["validation"]["passed"] is True
+        assert outcome["content"] == VALID_PYTHON
+        assert outcome["attempts"] == 1
+        assert outcome["used_fallback"] is False
+
+    def test_returns_fallback_after_max_retries(self):
+        outcome = generate_single_file("main.py", lambda: INVALID_PYTHON)
+        assert outcome["used_fallback"] is True
+        assert outcome["attempts"] == _MAX_RETRY_ATTEMPTS
+        assert "vibedeploy-fallback" in outcome["content"]
+        assert outcome["validation"]["passed"] is False
+
+    def test_fallback_content_for_py_uses_hash_comment(self):
+        outcome = generate_single_file("service.py", lambda: INVALID_PYTHON)
+        assert outcome["content"].startswith("#")
+
+    def test_fallback_content_for_tsx_uses_slash_comment(self):
+        outcome = generate_single_file("App.tsx", lambda: UNBALANCED_BRACE_TSX)
+        assert outcome["content"].startswith("//")
+
+    def test_custom_max_retries_respected(self):
+        call_count = 0
+
+        def bad_factory():
+            nonlocal call_count
+            call_count += 1
+            return INVALID_PYTHON
+
+        outcome = generate_single_file("main.py", bad_factory, max_retries=2)
+        assert call_count == 2
+        assert outcome["used_fallback"] is True
+        assert outcome["attempts"] == 2
+
+    def test_factory_exception_counts_as_failed_attempt(self):
+        call_count = 0
+
+        def exploding_factory():
+            nonlocal call_count
+            call_count += 1
+            raise ValueError("simulated generation error")
+
+        outcome = generate_single_file("main.py", exploding_factory, max_retries=3)
+        assert call_count == 3
+        assert outcome["used_fallback"] is True
+        assert "content_factory raised" in outcome["validation"]["error"]
+
+
+class TestGenerateFilesWithValidation:
+    def test_only_failed_file_retried_not_all(self):
+        files = {
+            "ok.py": VALID_PYTHON,
+            "broken.py": INVALID_PYTHON,
+            "also_ok.tsx": VALID_TSX,
+        }
+
+        result = generate_files_with_validation(files, max_retries=3)
+
+        assert result["retry_metadata"]["ok.py"]["attempts"] == 1
+        assert result["retry_metadata"]["ok.py"]["used_fallback"] is False
+        assert result["retry_metadata"]["also_ok.tsx"]["attempts"] == 1
+        assert result["retry_metadata"]["broken.py"]["used_fallback"] is True
+
+    def test_passing_files_content_unchanged(self):
+        files = {"ok.py": VALID_PYTHON, "app.tsx": VALID_TSX}
+        result = generate_files_with_validation(files)
+        assert result["files"]["ok.py"] == VALID_PYTHON
+        assert result["files"]["app.tsx"] == VALID_TSX
+
+    def test_validation_results_present_for_all_files(self):
+        files = {"ok.py": VALID_PYTHON, "broken.py": INVALID_PYTHON}
+        result = generate_files_with_validation(files)
+        assert "ok.py" in result["validation_results"]
+        assert "broken.py" in result["validation_results"]
+        assert result["validation_results"]["ok.py"]["passed"] is True
+
+    def test_failed_file_replaced_with_fallback_marker(self):
+        files = {"broken.py": INVALID_PYTHON}
+        result = generate_files_with_validation(files, max_retries=3)
+        assert "vibedeploy-fallback" in result["files"]["broken.py"]
+
+    def test_empty_files_dict_returns_empty_result(self):
+        result = generate_files_with_validation({})
+        assert result["files"] == {}
+        assert result["validation_results"] == {}
+        assert result["retry_metadata"] == {}


### PR DESCRIPTION
## Summary
- add Python/TS/TSX validation for per-file generation
- retry only failed files and emit fallback markers after max attempts
- preserve #49 public API while extending validation behavior

## Issue
Closes #50

## Local Validation
- [x] ruff check passed
- [x] pytest tests/test_per_file_codegen.py tests/test_per_file_ast_validation.py -v --tb=short passed
