### PR TITLE
fix(agent): wire real Gemini LLM call in insight extractor (#153)

### DIFF
--- a/agent/tests/test_insight_gemini.py
+++ b/agent/tests/test_insight_gemini.py
@@ -1,0 +1,215 @@
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent.zero_prompt.insight_extractor import (
+    _parse_appidea_from_text,
+    extract_insight_from_transcript,
+    extract_with_gemini,
+)
+from agent.zero_prompt.schemas import AppIdea
+
+_VALID_JSON = (
+    '{"name": "HealthTrack", "domain": "healthcare", "description": "An app for tracking health.", '
+    '"key_features": ["monitoring", "alerts"], "target_audience": "Patients", "confidence_score": 0.85}'
+)
+
+_VALID_JSON_FENCED = f"```json\n{_VALID_JSON}\n```"
+
+_VALID_JSON_PLAIN_FENCE = f"```\n{_VALID_JSON}\n```"
+
+
+def _make_response(text: str) -> MagicMock:
+    r = MagicMock()
+    r.text = text
+    return r
+
+
+def _make_client(first_text: str, second_text: str | None = None) -> MagicMock:
+    client = MagicMock()
+    responses = [_make_response(first_text)]
+    if second_text is not None:
+        responses.append(_make_response(second_text))
+    client.models.generate_content.side_effect = responses
+    return client
+
+
+@pytest.mark.asyncio
+async def test_no_api_key_returns_none(monkeypatch):
+    monkeypatch.delenv("GOOGLE_GENAI_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    assert await extract_with_gemini("some transcript") is None
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_key_returns_none(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "   ")
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    assert await extract_with_gemini("some transcript") is None
+
+
+@pytest.mark.asyncio
+async def test_gemini_api_key_fallback_also_checked(monkeypatch):
+    monkeypatch.delenv("GOOGLE_GENAI_API_KEY", raising=False)
+    monkeypatch.setenv("GEMINI_API_KEY", "fake-gemini-key")
+
+    client = _make_client(_VALID_JSON)
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health app for patients.")
+
+    assert isinstance(result, AppIdea)
+    assert result.name == "HealthTrack"
+
+
+@pytest.mark.asyncio
+async def test_successful_extraction_plain_json(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client(_VALID_JSON)
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health monitoring application.")
+
+    assert isinstance(result, AppIdea)
+    assert result.domain == "healthcare"
+    assert result.confidence_score == pytest.approx(0.85)
+    assert client.models.generate_content.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_successful_extraction_fenced_json(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client(_VALID_JSON_FENCED)
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health monitoring application.")
+
+    assert isinstance(result, AppIdea)
+    assert result.name == "HealthTrack"
+
+
+@pytest.mark.asyncio
+async def test_successful_extraction_plain_fence(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client(_VALID_JSON_PLAIN_FENCE)
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health monitoring application.")
+
+    assert isinstance(result, AppIdea)
+
+
+@pytest.mark.asyncio
+async def test_parse_failure_triggers_retry(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client("NOT VALID JSON AT ALL", _VALID_JSON)
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health app.")
+
+    assert isinstance(result, AppIdea)
+    assert client.models.generate_content.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_retry_repair_prompt_mentions_error(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client("bad json", _VALID_JSON)
+    with patch("google.genai.Client", return_value=client):
+        await extract_with_gemini("A health app.")
+
+    second_call_contents = client.models.generate_content.call_args_list[1][1].get(
+        "contents",
+        client.models.generate_content.call_args_list[1][0][0]
+        if client.models.generate_content.call_args_list[1][0]
+        else "",
+    )
+    assert "Error" in str(second_call_contents) or "failed" in str(second_call_contents).lower()
+
+
+@pytest.mark.asyncio
+async def test_double_parse_failure_returns_none(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client("bad json", "still bad json")
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health app.")
+
+    assert result is None
+    assert client.models.generate_content.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_api_exception_returns_none(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = MagicMock()
+    client.models.generate_content.side_effect = RuntimeError("API unavailable")
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health app.")
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_empty_response_text_returns_none_after_retry(monkeypatch):
+    monkeypatch.setenv("GOOGLE_GENAI_API_KEY", "fake-key")
+
+    client = _make_client("", "")
+    with patch("google.genai.Client", return_value=client):
+        result = await extract_with_gemini("A health app.")
+
+    assert result is None
+
+
+def test_rule_based_fallback_works_without_gemini():
+    result = extract_insight_from_transcript("A fitness app that tracks workouts and calories burned.")
+    assert isinstance(result, AppIdea)
+    assert result.domain == "fitness"
+    assert result.confidence_score >= 0.0
+
+
+def test_rule_based_fallback_unaffected_by_gemini_import_error(monkeypatch):
+    monkeypatch.delenv("GOOGLE_GENAI_API_KEY", raising=False)
+    result = extract_insight_from_transcript("Social network for developers to connect and share code.")
+    assert isinstance(result, AppIdea)
+    assert len(result.target_audience) > 0
+
+
+def test_parse_appidea_plain_json():
+    result = _parse_appidea_from_text(_VALID_JSON)
+    assert isinstance(result, AppIdea)
+    assert result.name == "HealthTrack"
+
+
+def test_parse_appidea_json_fence():
+    result = _parse_appidea_from_text(_VALID_JSON_FENCED)
+    assert isinstance(result, AppIdea)
+
+
+def test_parse_appidea_plain_fence():
+    result = _parse_appidea_from_text(_VALID_JSON_PLAIN_FENCE)
+    assert isinstance(result, AppIdea)
+
+
+def test_parse_appidea_invalid_raises():
+    with pytest.raises(Exception):
+        _parse_appidea_from_text("not json at all")
+
+
+@pytest.mark.skipif(not os.getenv("GOOGLE_GENAI_API_KEY"), reason="GOOGLE_GENAI_API_KEY not set")
+@pytest.mark.asyncio
+async def test_live_extract_with_gemini_returns_app_idea():
+    transcript = (
+        "In this video I'll show you how to build a fitness tracking app. "
+        "The app allows users to log workouts, track calories, and monitor progress. "
+        "Features include a workout library, progress charts, and social sharing. "
+        "Target audience: fitness enthusiasts and gym-goers."
+    )
+    result = await extract_with_gemini(transcript)
+    assert result is None or isinstance(result, AppIdea)
+    if result is not None:
+        assert result.name
+        assert result.domain
+        assert 0.0 <= result.confidence_score <= 1.0

--- a/agent/zero_prompt/insight_extractor.py
+++ b/agent/zero_prompt/insight_extractor.py
@@ -1,3 +1,5 @@
+import asyncio
+import json
 import logging
 import os
 import re
@@ -159,12 +161,66 @@ def extract_insight_from_transcript(transcript_text: str, video_title: str = "")
     )
 
 
+def _parse_appidea_from_text(raw: str) -> AppIdea:
+    text = raw.strip()
+    if "```json" in text:
+        text = text.split("```json", 1)[1].split("```", 1)[0].strip()
+    elif "```" in text:
+        text = text.split("```", 1)[1].split("```", 1)[0].strip()
+    data = json.loads(text)
+    return AppIdea(**data)
+
+
 async def extract_with_gemini(transcript_text: str) -> AppIdea | None:
-    api_key = os.environ.get("GOOGLE_GENAI_API_KEY", "").strip()
+    api_key = (os.environ.get("GOOGLE_GENAI_API_KEY", "") or os.environ.get("GEMINI_API_KEY", "")).strip()
     if not api_key:
         logger.debug("GOOGLE_GENAI_API_KEY not set — skipping Gemini extraction")
         return None
-    # TODO: wire real Gemini call — import google.generativeai, configure with api_key,
-    #       call model.generate_content(transcript_text[:4000]), parse response into AppIdea.
-    logger.info("GOOGLE_GENAI_API_KEY present — Gemini stub reached (not yet implemented)")
-    return None
+
+    try:
+        from google import genai  # noqa: PLC0415
+
+        client = genai.Client(api_key=api_key)
+
+        prompt = (
+            "Analyze this video transcript and extract an app idea.\n"
+            "Return JSON with fields: name, domain, description, "
+            "key_features (list), target_audience, confidence_score (0.0-1.0).\n\n"
+            f"Transcript:\n{transcript_text[:3000]}"
+        )
+
+        response = await asyncio.to_thread(
+            client.models.generate_content,
+            model="gemini-2.0-flash-lite",
+            contents=prompt,
+        )
+
+        raw = response.text or ""
+        try:
+            return _parse_appidea_from_text(raw)
+        except Exception as parse_err:
+            logger.warning("Gemini first parse failed (%s) — attempting self-repair", parse_err)
+
+            repair_prompt = (
+                "Your previous response failed to parse as a valid JSON AppIdea.\n"
+                f"Error: {parse_err}\n\n"
+                "Return ONLY valid JSON with exactly these fields:\n"
+                "  name (string), domain (string), description (string),\n"
+                "  key_features (list of strings), target_audience (string),\n"
+                "  confidence_score (float 0.0-1.0).\n\n"
+                f"Transcript:\n{transcript_text[:3000]}"
+            )
+            repair_response = await asyncio.to_thread(
+                client.models.generate_content,
+                model="gemini-2.0-flash-lite",
+                contents=repair_prompt,
+            )
+            try:
+                return _parse_appidea_from_text(repair_response.text or "")
+            except Exception:
+                logger.warning("Gemini self-repair failed — caller will use rule-based fallback")
+                return None
+
+    except Exception:
+        logger.warning("Gemini extraction failed — caller will use rule-based fallback", exc_info=True)
+        return None


### PR DESCRIPTION
## Summary
- Replace extract_with_gemini stub with real google.genai call
- 1 self-repair retry, rule-based fallback when no API key
- 17 unit tests (mocked), 1 live test (skipped without key)

## Issue
Closes #153
