### PR TITLE
feat: kanban 5-card height + NO-GO delete button

### DIFF
--- a/agent/tests/test_streaming_orchestrator.py
+++ b/agent/tests/test_streaming_orchestrator.py
@@ -2,7 +2,7 @@ import pytest
 
 from agent.zero_prompt.events import ZP_GO, ZP_NOGO, ZP_SESSION_START
 from agent.zero_prompt.orchestrator import StreamingOrchestrator
-from agent.zero_prompt.schemas import ZPSession
+from agent.zero_prompt.schemas import ZPCard, ZPSession
 
 
 async def _go_verdict(session_id: str, video_id: str, card_id: str) -> tuple[str, int, str, str]:
@@ -261,12 +261,21 @@ class TestDeleteCard:
         assert card.status == "deleted"
 
     @pytest.mark.asyncio
-    async def test_delete_non_go_ready_returns_error(self):
+    async def test_delete_nogo_card_succeeds(self):
         orch = StreamingOrchestrator()
         session, _ = orch.create_session()
         await orch.exploration_step(session.session_id, "v1", verdict_fn=_nogo_verdict)
         card = session.cards[0]
         result = orch.delete_card(session.session_id, card.card_id)
+        assert result["type"] == "zp.action.delete_card"
+        assert card.status == "deleted"
+
+    def test_delete_building_card_returns_error(self):
+        orch = StreamingOrchestrator()
+        session, _ = orch.create_session()
+        card = ZPCard(card_id="c1", video_id="v1", status="building", score=70)
+        session.cards.append(card)
+        result = orch.delete_card(session.session_id, "c1")
         assert result["type"] == "zp.action.error"
 
 

--- a/agent/zero_prompt/orchestrator.py
+++ b/agent/zero_prompt/orchestrator.py
@@ -321,7 +321,7 @@ class StreamingOrchestrator:
         if card is None:
             return {"type": "zp.action.error", "error": "card_not_found"}
 
-        if card.status != "go_ready":
+        if card.status not in ("go_ready", "nogo", "passed", "build_failed", "deleted"):
             return {"type": "zp.action.error", "error": "card_not_deletable"}
 
         card.status = "deleted"

--- a/web/src/app/zero-prompt/page.tsx
+++ b/web/src/app/zero-prompt/page.tsx
@@ -32,7 +32,8 @@ function ZeroPromptInner() {
     startSession, 
     restoreSession,
     queueBuild, 
-    passCard 
+    passCard,
+    deleteCard
   } = useZeroPrompt();
   
   const [goal, setGoal] = useState<string>("");
@@ -155,7 +156,8 @@ function ZeroPromptInner() {
         <KanbanBoard 
           cards={session?.cards || []} 
           onQueueBuild={queueBuild} 
-          onPassCard={passCard} 
+          onPassCard={passCard}
+          onDeleteCard={deleteCard}
         />
         
         <ActionFeed actions={actions} />

--- a/web/src/components/zero-prompt/idea-card.tsx
+++ b/web/src/components/zero-prompt/idea-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Play, X, ExternalLink, Loader2 } from "lucide-react";
+import { Play, X, ExternalLink, Loader2, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import type { ZPCard } from "@/types/zero-prompt";
@@ -10,10 +10,11 @@ interface IdeaCardProps {
   card: ZPCard;
   onQueueBuild: (cardId: string) => void;
   onPassCard: (cardId: string) => void;
+  onDeleteCard?: (cardId: string) => void;
   onClick?: (card: ZPCard) => void;
 }
 
-export function IdeaCard({ card, onQueueBuild, onPassCard, onClick }: IdeaCardProps) {
+export function IdeaCard({ card, onQueueBuild, onPassCard, onDeleteCard, onClick }: IdeaCardProps) {
   return (
     <motion.div
       layoutId={card.card_id}
@@ -61,6 +62,19 @@ export function IdeaCard({ card, onQueueBuild, onPassCard, onClick }: IdeaCardPr
           <div className="flex items-center justify-center gap-2 mt-3 text-xs text-muted-foreground bg-muted/50 py-1.5 rounded">
             <Loader2 className="w-3 h-3 animate-spin" />
             {card.status === "build_queued" ? "Queued..." : "Building..."}
+          </div>
+        )}
+
+        {(card.status === "nogo" || card.status === "passed" || card.status === "build_failed") && onDeleteCard && (
+          <div className="flex gap-2 mt-3" onClick={(e) => e.stopPropagation()}>
+            <Button 
+              size="sm" 
+              variant="ghost" 
+              className="flex-1 h-8 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+              onClick={() => onDeleteCard(card.card_id)}
+            >
+              <Trash2 className="w-3 h-3 mr-1" /> 삭제
+            </Button>
           </div>
         )}
 

--- a/web/src/components/zero-prompt/kanban-board.tsx
+++ b/web/src/components/zero-prompt/kanban-board.tsx
@@ -9,6 +9,7 @@ interface KanbanBoardProps {
   cards: ZPCard[];
   onQueueBuild: (cardId: string) => void;
   onPassCard: (cardId: string) => void;
+  onDeleteCard?: (cardId: string) => void;
 }
 
 const COLUMNS: { id: string; title: string; statuses: CardStatus[] }[] = [
@@ -19,7 +20,7 @@ const COLUMNS: { id: string; title: string; statuses: CardStatus[] }[] = [
   { id: "nogo", title: "NO-GO / 패스", statuses: ["nogo", "passed", "build_failed"] },
 ];
 
-export function KanbanBoard({ cards, onQueueBuild, onPassCard }: KanbanBoardProps) {
+export function KanbanBoard({ cards, onQueueBuild, onPassCard, onDeleteCard }: KanbanBoardProps) {
   const [selectedCard, setSelectedCard] = useState<ZPCard | null>(null);
 
   return (
@@ -34,6 +35,7 @@ export function KanbanBoard({ cards, onQueueBuild, onPassCard }: KanbanBoardProp
             cards={cards}
             onQueueBuild={onQueueBuild}
             onPassCard={onPassCard}
+            onDeleteCard={onDeleteCard}
             onCardClick={setSelectedCard}
           />
         ))}

--- a/web/src/components/zero-prompt/kanban-column.tsx
+++ b/web/src/components/zero-prompt/kanban-column.tsx
@@ -11,10 +11,11 @@ interface KanbanColumnProps {
   cards: ZPCard[];
   onQueueBuild: (cardId: string) => void;
   onPassCard: (cardId: string) => void;
+  onDeleteCard?: (cardId: string) => void;
   onCardClick?: (card: ZPCard) => void;
 }
 
-export function KanbanColumn({ title, statuses, cards, onQueueBuild, onPassCard, onCardClick }: KanbanColumnProps) {
+export function KanbanColumn({ title, statuses, cards, onQueueBuild, onPassCard, onDeleteCard, onCardClick }: KanbanColumnProps) {
   const columnCards = cards.filter((c) => statuses.includes(c.status));
 
   return (
@@ -24,7 +25,7 @@ export function KanbanColumn({ title, statuses, cards, onQueueBuild, onPassCard,
         <Badge variant="secondary" className="text-xs">{columnCards.length}</Badge>
       </div>
       
-      <div className="flex flex-col gap-3 flex-1 max-h-[600px] overflow-y-auto pr-1">
+      <div className="flex flex-col gap-3 flex-1 max-h-[688px] overflow-y-auto pr-1">
         {columnCards.length === 0 ? (
           <div className="flex-1 flex items-center justify-center text-sm text-muted-foreground border-2 border-dashed border-border/50 rounded-lg p-4">
             Empty
@@ -36,6 +37,7 @@ export function KanbanColumn({ title, statuses, cards, onQueueBuild, onPassCard,
               card={card} 
               onQueueBuild={onQueueBuild} 
               onPassCard={onPassCard}
+              onDeleteCard={onDeleteCard}
               onClick={onCardClick}
             />
           ))

--- a/web/src/hooks/use-zero-prompt.ts
+++ b/web/src/hooks/use-zero-prompt.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
-import { getSession, startSession, queueBuild, passCard } from "@/lib/zero-prompt-api";
+import { getSession, startSession, queueBuild, passCard, deleteCard } from "@/lib/zero-prompt-api";
 import type { ZPSession, ZPAction } from "@/types/zero-prompt";
 
 function formatEventMessage(data: Record<string, unknown>): string {
@@ -140,6 +140,16 @@ export function useZeroPrompt() {
     }
   };
 
+  const handleDeleteCard = async (cardId: string) => {
+    if (!session) return;
+    try {
+      await deleteCard(session.session_id, cardId);
+      await fetchSession(session.session_id);
+    } catch (err) {
+      console.error("Failed to delete card", err);
+    }
+  };
+
   const restoreSession = useCallback(async (id: string) => {
     sessionIdRef.current = id;
     await fetchSession(id);
@@ -157,5 +167,6 @@ export function useZeroPrompt() {
     restoreSession,
     queueBuild: handleQueueBuild,
     passCard: handlePassCard,
+    deleteCard: handleDeleteCard,
   };
 }

--- a/web/src/lib/zero-prompt-api.ts
+++ b/web/src/lib/zero-prompt-api.ts
@@ -34,3 +34,12 @@ export async function passCard(sessionId: string, cardId: string): Promise<void>
   });
   if (!response.ok) throw new Error("Failed to pass card");
 }
+
+export async function deleteCard(sessionId: string, cardId: string): Promise<void> {
+  const response = await fetch(`${DASHBOARD_API_URL}/zero-prompt/${sessionId}/actions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ action: "delete_card", card_id: cardId }),
+  });
+  if (!response.ok) throw new Error("Failed to delete card");
+}


### PR DESCRIPTION
## Summary

- 칸반 컬럼 높이를 카드 5개 기준 **688px**로 고정, 초과 시 세로 스크롤
- NO-GO/패스/빌드실패 카드에 **삭제** 버튼 추가 (엔드투엔드 동작)

## Changes (7 files)

| File | Change |
|------|--------|
| `web/src/components/zero-prompt/kanban-column.tsx` | `max-h-[688px] overflow-y-auto` + `onDeleteCard` prop |
| `web/src/components/zero-prompt/idea-card.tsx` | Trash2 삭제 버튼 (nogo/passed/build_failed) |
| `web/src/components/zero-prompt/kanban-board.tsx` | `onDeleteCard` prop 전달 |
| `web/src/app/zero-prompt/page.tsx` | `deleteCard` 훅 연결 |
| `web/src/hooks/use-zero-prompt.ts` | `handleDeleteCard` + import |
| `web/src/lib/zero-prompt-api.ts` | `deleteCard()` API 함수 추가 |
| `agent/zero_prompt/orchestrator.py` | `delete_card` 상태 제한 확장 (nogo/passed/build_failed 허용) |

## Flow

```
NO-GO 카드 → [삭제] 클릭
  → POST /zero-prompt/{sessionId}/actions { action: "delete_card", card_id }
  → orchestrator.delete_card() → card.status = "deleted"
  → fetchSession() → 칸반에서 카드 사라짐
```

Refs #200 (BUG 11 + BUG 14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
- 특정 상태의 카드(미승인, 승인, 빌드 실패)에 대한 삭제 기능 추가
- Kanban 보드에 삭제 버튼 추가로 불필요한 카드를 쉽게 제거 가능
- 삭제된 카드는 "deleted" 상태로 유지되어 카드 관리 워크플로우 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->