### PR TITLE
feat: add build status visibility to live monitor

### DIFF
--- a/agent/nodes/build_validator.py
+++ b/agent/nodes/build_validator.py
@@ -4,6 +4,8 @@ import logging
 import tempfile
 from pathlib import Path
 
+from langchain_core.callbacks.manager import adispatch_custom_event
+
 from ..state import VibeDeployState
 
 logger = logging.getLogger(__name__)
@@ -109,17 +111,62 @@ async def _run_docker_frontend(frontend_code: dict, docker_client) -> tuple[bool
             return False, str(stderr) or str(exc)
 
 
-async def build_validator(state: VibeDeployState) -> dict:
+async def _emit_build_event(
+    event_name: str,
+    *,
+    config,
+    node: str,
+    phase: str,
+    message: str,
+    **extra,
+) -> None:
+    if config is None:
+        return
+    payload = {
+        "type": event_name,
+        "node": node,
+        "stage": node,
+        "phase": phase,
+        "message": message,
+        **extra,
+    }
+    await adispatch_custom_event(event_name, payload, config=config)
+
+
+async def build_validator(state: VibeDeployState, config=None) -> dict:
     backend_code = state.get("backend_code") or {}
     frontend_code = state.get("frontend_code") or {}
 
+    await _emit_build_event(
+        "build.node.start",
+        config=config,
+        node="build_validator",
+        phase="build_validation",
+        message="Validating build...",
+    )
+
     if backend_code:
+        await _emit_build_event(
+            "build.step.start",
+            config=config,
+            node="build_validator",
+            phase="build_validation",
+            message="Checking Python syntax...",
+        )
         syntax_errors = _ast_check_python_files(backend_code)
         if syntax_errors:
             logger.warning("[BUILD_VALIDATOR] Python syntax errors detected: %s", syntax_errors)
             combined_stderr = "\n".join(syntax_errors)
             trimmed = _trim_build_errors(combined_stderr)
             repair_prompt = _build_repair_prompt(trimmed, backend_code)
+            await _emit_build_event(
+                "build.node.error",
+                config=config,
+                node="build_validator",
+                phase="build_validation",
+                message="Python syntax errors detected",
+                errors=syntax_errors,
+            )
             return {
                 "build_validation": {
                     "passed": False,
@@ -137,6 +184,14 @@ async def build_validator(state: VibeDeployState) -> dict:
         import docker.errors  # type: ignore[import]
     except ImportError:
         logger.warning("[BUILD_VALIDATOR] docker SDK not installed; skipping container validation")
+        await _emit_build_event(
+            "build.node.complete",
+            config=config,
+            node="build_validator",
+            phase="build_validation",
+            message="Build validation skipped: Docker not available",
+            skipped=True,
+        )
         return {
             "build_validation": {
                 "passed": True,
@@ -150,6 +205,14 @@ async def build_validator(state: VibeDeployState) -> dict:
         docker_client.ping()
     except Exception as exc:
         logger.warning("[BUILD_VALIDATOR] Docker daemon not reachable (%s); skipping container validation", exc)
+        await _emit_build_event(
+            "build.node.complete",
+            config=config,
+            node="build_validator",
+            phase="build_validation",
+            message="Build validation skipped: Docker not available",
+            skipped=True,
+        )
         return {
             "build_validation": {
                 "passed": True,
@@ -164,6 +227,13 @@ async def build_validator(state: VibeDeployState) -> dict:
 
     if backend_code and "requirements.txt" in backend_code and "main.py" in backend_code:
         logger.info("[BUILD_VALIDATOR] Running backend build validation in Docker")
+        await _emit_build_event(
+            "build.step.start",
+            config=config,
+            node="build_validator",
+            phase="build_validation",
+            message="Running backend build in Docker...",
+        )
         backend_ok, backend_err = await _run_docker_backend(backend_code, docker_client)
         if not backend_ok:
             logger.warning("[BUILD_VALIDATOR] Backend Docker validation failed: %s", backend_err[:500])
@@ -171,6 +241,13 @@ async def build_validator(state: VibeDeployState) -> dict:
 
     if frontend_code and "package.json" in frontend_code:
         logger.info("[BUILD_VALIDATOR] Running frontend build validation in Docker")
+        await _emit_build_event(
+            "build.step.start",
+            config=config,
+            node="build_validator",
+            phase="build_validation",
+            message="Running frontend build in Docker...",
+        )
         frontend_ok, frontend_err = await _run_docker_frontend(frontend_code, docker_client)
         if not frontend_ok:
             logger.warning("[BUILD_VALIDATOR] Frontend Docker validation failed: %s", frontend_err[:500])
@@ -178,6 +255,16 @@ async def build_validator(state: VibeDeployState) -> dict:
 
     passed = backend_ok and frontend_ok
     if passed:
+        await _emit_build_event(
+            "build.node.complete",
+            config=config,
+            node="build_validator",
+            phase="build_validation",
+            message="Build validation passed",
+            passed=True,
+            backend_ok=backend_ok,
+            frontend_ok=frontend_ok,
+        )
         return {
             "build_validation": {
                 "passed": True,
@@ -194,6 +281,18 @@ async def build_validator(state: VibeDeployState) -> dict:
     if not frontend_ok:
         failing_files.update(frontend_code)
     repair_prompt = _build_repair_prompt(trimmed, failing_files)
+    await _emit_build_event(
+        "build.node.error",
+        config=config,
+        node="build_validator",
+        phase="build_validation",
+        message="Build validation failed",
+        passed=False,
+        backend_ok=backend_ok,
+        frontend_ok=frontend_ok,
+        errors=errors,
+        attempt=state.get("build_attempt_count", 0) + 1,
+    )
 
     return {
         "build_validation": {

--- a/agent/nodes/code_evaluator.py
+++ b/agent/nodes/code_evaluator.py
@@ -2,6 +2,8 @@ import json
 import logging
 import re
 
+from langchain_core.callbacks.manager import adispatch_custom_event
+
 from ..state import VibeDeployState
 from .task_contracts import build_repair_tasks_from_eval, build_task_distribution
 
@@ -69,7 +71,7 @@ _SHALLOW_CONTENT_PATTERNS = (
 _MIN_UNIQUE_API_ENDPOINTS = 2
 
 
-async def code_evaluator(state: VibeDeployState) -> dict:
+async def code_evaluator(state: VibeDeployState, config=None) -> dict:
     blueprint = state.get("blueprint", {})
     frontend_code = state.get("frontend_code", {})
     backend_code = state.get("backend_code", {})
@@ -150,6 +152,27 @@ async def code_evaluator(state: VibeDeployState) -> dict:
         experience,
         "PASS" if eval_result["passed"] else f"FAIL (iter {iteration}/{MAX_CODE_EVAL_ITERATIONS})",
     )
+
+    if config is not None:
+        await adispatch_custom_event(
+            "code_eval.result",
+            {
+                "type": "code_eval.result",
+                "node": "code_evaluator",
+                "phase": "code_evaluation",
+                "message": f"Code evaluation {'PASSED' if eval_result['passed'] else f'iteration {iteration}/{MAX_CODE_EVAL_ITERATIONS}'}",
+                "passed": eval_result["passed"],
+                "iteration": iteration,
+                "max_iterations": MAX_CODE_EVAL_ITERATIONS,
+                "match_rate": match_rate,
+                "completeness": round(completeness, 1),
+                "consistency": round(consistency, 1),
+                "runnability": round(runnability, 1),
+                "experience": round(experience, 1),
+                "blockers": blockers,
+            },
+            config=config,
+        )
 
     return {
         "code_eval_result": eval_result,

--- a/agent/nodes/deployer.py
+++ b/agent/nodes/deployer.py
@@ -180,7 +180,7 @@ async def deployer(state: VibeDeployState, config=None) -> dict:
     if github_full_name and commit_sha:
         await _emit_step_start("ci_test", "Running CI workflow", config=config, commit_sha=commit_sha)
         ci_result, all_files, repair_attempts = await _ci_repair_loop(
-            github_full_name, commit_sha, all_files, max_retries=3
+            github_full_name, commit_sha, all_files, max_retries=3, config=config
         )
         ci_status = ci_result.get("status", "skipped")
         if ci_status in {"passed", "skipped"}:
@@ -321,6 +321,13 @@ async def deployer(state: VibeDeployState, config=None) -> dict:
             break
 
         logger.warning("[DEPLOYER] Deploy attempt %d failed. Repairing from error logs.", attempt + 1)
+        await _emit_step_start(
+            "do_build",
+            f"Deploy repair attempt {attempt + 1}/3",
+            config=config,
+            deploy_repair_attempt=attempt + 1,
+        )
+
         fixed_files = await _repair_code_from_errors(all_files, error_logs)
         if fixed_files == all_files:
             logger.warning("[DEPLOYER] LLM could not fix deploy errors (attempt %d)", attempt + 1)
@@ -341,6 +348,13 @@ async def deployer(state: VibeDeployState, config=None) -> dict:
         if redeploy_result.get("status") == "error":
             logger.warning("[DEPLOYER] Redeploy trigger failed: %s", redeploy_result.get("error", ""))
             break
+
+        await _emit_step_complete(
+            "do_build",
+            f"Deploy repair attempt {attempt + 1} — redeploying",
+            config=config,
+            deploy_repair_attempt=attempt + 1,
+        )
 
         deploy_repair_attempts = attempt + 1
 
@@ -561,6 +575,7 @@ async def _ci_repair_loop(
     commit_sha: str,
     files: dict[str, str],
     max_retries: int = 3,
+    config=None,
 ) -> tuple[dict, dict[str, str], int]:
     for attempt in range(1, max_retries + 1):
         ci_result = await wait_for_ci(full_name, commit_sha, timeout=180)
@@ -575,6 +590,14 @@ async def _ci_repair_loop(
         if not error_logs:
             return ci_result, files, attempt
 
+        await _emit_step_start(
+            "ci_test",
+            f"CI repair attempt {attempt}/{max_retries}",
+            config=config,
+            ci_repair_attempt=attempt,
+            max_retries=max_retries,
+        )
+
         fixed_files = await _repair_code_from_errors(files, error_logs)
         if fixed_files == files:
             return ci_result, files, attempt
@@ -588,6 +611,15 @@ async def _ci_repair_loop(
         commit_sha = push_result.get("commit_sha", "")
         if not commit_sha:
             return ci_result, files, attempt
+
+        if commit_sha:
+            await _emit_step_complete(
+                "ci_test",
+                f"CI repair attempt {attempt} pushed — re-running CI",
+                config=config,
+                ci_repair_attempt=attempt,
+                commit_sha=commit_sha,
+            )
 
     final_ci = await wait_for_ci(full_name, commit_sha, timeout=180)
     return final_ci, files, max_retries

--- a/agent/tests/test_build_validator.py
+++ b/agent/tests/test_build_validator.py
@@ -201,3 +201,54 @@ def test_write_files_to_tmpdir_skips_non_string_values(tmp_path):
 
     assert (tmp_path / "main.py").exists()
     assert not (tmp_path / "bad.py").exists()
+
+
+@pytest.mark.asyncio
+async def test_build_validator_emits_events_when_config_provided():
+    """Verify that build_validator emits SSE events when a config is supplied."""
+    emitted_events = []
+
+    async def _capture_event(name, payload, *, config):
+        emitted_events.append({"name": name, "payload": payload})
+
+    with (
+        patch("agent.nodes.build_validator.adispatch_custom_event", side_effect=_capture_event),
+        patch.dict("sys.modules", {"docker": None, "docker.errors": None}),
+    ):
+        result = await build_validator(
+            {
+                "backend_code": {"main.py": "x = 1\n", "requirements.txt": "fastapi\n"},
+                "frontend_code": {},
+            },
+            config={"configurable": {"thread_id": "test-thread"}},
+        )
+
+    assert result["build_validation"]["passed"] is True  # Docker skipped
+    assert len(emitted_events) >= 2  # At least node.start and node.complete
+    event_types = [e["payload"]["type"] for e in emitted_events]
+    assert "build.node.start" in event_types
+    # Should have complete or skip event
+    assert any(t in event_types for t in ("build.node.complete",))
+
+
+@pytest.mark.asyncio
+async def test_build_validator_emits_error_event_on_syntax_failure():
+    """Verify that build_validator emits an error event when Python syntax check fails."""
+    emitted_events = []
+
+    async def _capture_event(name, payload, *, config):
+        emitted_events.append({"name": name, "payload": payload})
+
+    with patch("agent.nodes.build_validator.adispatch_custom_event", side_effect=_capture_event):
+        result = await build_validator(
+            {
+                "backend_code": {"main.py": "def broken(\n    pass\n", "requirements.txt": "fastapi\n"},
+                "frontend_code": {},
+            },
+            config={"configurable": {"thread_id": "test-thread"}},
+        )
+
+    assert result["build_validation"]["passed"] is False
+    event_types = [e["payload"]["type"] for e in emitted_events]
+    assert "build.node.start" in event_types
+    assert "build.node.error" in event_types

--- a/agent/tests/test_code_evaluator.py
+++ b/agent/tests/test_code_evaluator.py
@@ -363,3 +363,42 @@ async def test_code_evaluator_returns_repair_tasks_for_blockers():
     assert repair_tasks
     assert any(task["target"] == "frontend" for task in repair_tasks)
     assert result["task_distribution"]["total"] >= len(repair_tasks)
+
+
+@pytest.mark.asyncio
+async def test_code_evaluator_emits_result_event_when_config_provided():
+    """Verify that code_evaluator emits a code_eval.result event with scores."""
+    from unittest.mock import patch
+
+    emitted_events = []
+
+    async def _capture_event(name, payload, *, config):
+        emitted_events.append({"name": name, "payload": payload})
+
+    with patch("agent.nodes.code_evaluator.adispatch_custom_event", side_effect=_capture_event):
+        await code_evaluator(
+            {
+                "blueprint": {
+                    "frontend_files": {"package.json": {}, "src/app/page.tsx": {}},
+                    "backend_files": {"main.py": {}, "requirements.txt": {}},
+                },
+                "frontend_code": {
+                    "package.json": '{"dependencies":{"next":"15.0.0"}}',
+                    "src/app/page.tsx": "export default function Page(){ return <main>Hello</main>; }",
+                },
+                "backend_code": {
+                    "main.py": "from fastapi import FastAPI\napp = FastAPI()\n",
+                    "requirements.txt": "fastapi\nuvicorn\n",
+                },
+            },
+            config={"configurable": {"thread_id": "test-thread"}},
+        )
+
+    assert len(emitted_events) == 1
+    event = emitted_events[0]
+    assert event["name"] == "code_eval.result"
+    assert event["payload"]["type"] == "code_eval.result"
+    assert "match_rate" in event["payload"]
+    assert "iteration" in event["payload"]
+    assert "passed" in event["payload"]
+    assert event["payload"]["node"] == "code_evaluator"

--- a/web/src/app/dashboard/page.tsx
+++ b/web/src/app/dashboard/page.tsx
@@ -49,7 +49,7 @@ export default function DashboardPage() {
     scoreTrend,
   } = useDashboard();
 
-  const { activePipelines, events, nodeStatuses, connected } = usePipelineMonitor();
+  const { activePipelines, events, nodeStatuses, nodeMetadata, connected } = usePipelineMonitor();
 
   const highestScore = useMemo(() => {
     if (!results.length) return 0;
@@ -253,7 +253,7 @@ export default function DashboardPage() {
                     <Badge variant="outline" className="border-cyan-500/20 bg-cyan-500/10 text-cyan-200">Git Push · CI Test · App Spec · Build · Deploy · Verified Live</Badge>
                   </div>
                 </div>
-                <PipelineViz pipeline="evaluation" />
+                <PipelineViz pipeline="evaluation" activeNodes={nodeStatuses} nodeMetadata={nodeMetadata} />
               </motion.div>
 
               <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
@@ -349,6 +349,7 @@ export default function DashboardPage() {
                     activePipelines={activePipelines}
                     events={events}
                     nodeStatuses={nodeStatuses}
+                    nodeMetadata={nodeMetadata}
                     connected={connected}
                   />
                 </motion.div>

--- a/web/src/components/dashboard/live-monitor.tsx
+++ b/web/src/components/dashboard/live-monitor.tsx
@@ -8,12 +8,13 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { Wifi, WifiOff, Activity, Clock, Brain, Target, Play, Workflow, Radio } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { PipelineViz } from "./pipeline-viz";
-import type { ActivePipeline, DashboardEvent, PipelineNodeStatus } from "@/types/dashboard";
+import type { ActivePipeline, DashboardEvent, NodeMetadata, PipelineNodeStatus } from "@/types/dashboard";
 
 interface LiveMonitorProps {
   activePipelines: ActivePipeline[];
   events: DashboardEvent[];
   nodeStatuses: Record<string, PipelineNodeStatus>;
+  nodeMetadata?: Record<string, NodeMetadata>;
   connected: boolean;
 }
 
@@ -128,7 +129,7 @@ function EventFeed({ events }: { events: DashboardEvent[] }) {
   );
 }
 
-export function LiveMonitor({ activePipelines, events, nodeStatuses, connected }: LiveMonitorProps) {
+export function LiveMonitor({ activePipelines, events, nodeStatuses, nodeMetadata, connected }: LiveMonitorProps) {
   const activePipeline = activePipelines[0];
   const latestEvent = events[0];
 
@@ -244,7 +245,7 @@ export function LiveMonitor({ activePipelines, events, nodeStatuses, connected }
                     Live node states align to the exact named steps now in flight, including the five council agents, the five score axes, prompt strategy, CI, build, deploy, and live verification.
                   </p>
                 </div>
-                <PipelineViz pipeline={activePipeline.type} activeNodes={nodeStatuses} />
+                <PipelineViz pipeline={activePipeline.type} activeNodes={nodeStatuses} nodeMetadata={nodeMetadata} />
               </div>
             </>
           ) : (

--- a/web/src/components/dashboard/pipeline-viz.tsx
+++ b/web/src/components/dashboard/pipeline-viz.tsx
@@ -11,6 +11,7 @@ export type NodeStatus = "idle" | "active" | "complete" | "error";
 
 interface PipelineVizProps {
   activeNodes?: Record<string, NodeStatus>;
+  nodeMetadata?: Record<string, { iteration?: number; maxIterations?: number; repairAttempt?: number; maxRepairs?: number; matchRate?: number; skipped?: boolean }>;
   pipeline?: PipelineType;
   className?: string;
 }
@@ -80,6 +81,7 @@ const evalNodes: NodeDef[] = [
   { id: "prompt_strategy", label: "Prompt Strategist", x: 62, y: 68, emoji: "🧭" },
   { id: "code_gen", label: "Code Generator", x: 80, y: 68, emoji: "💻" },
   { id: "code_eval", label: "Code Evaluator", x: 50, y: 76, emoji: "✅" },
+  { id: "build_validate", label: "Build Validate", x: 50, y: 81, emoji: "🔨" },
   { id: "git_push", label: "Git Push", x: 8, y: 86, emoji: "📦" },
   { id: "ci_test", label: "CI Test", x: 24, y: 86, emoji: "⚙️" },
   { id: "app_spec", label: "App Spec", x: 40, y: 86, emoji: "📋" },
@@ -124,7 +126,8 @@ const evalEdges: EdgeDef[] = [
   { source: "blueprint", target: "prompt_strategy" },
   { source: "prompt_strategy", target: "code_gen" },
   { source: "code_gen", target: "code_eval" },
-  { source: "code_eval", target: "git_push" },
+  { source: "code_eval", target: "build_validate" },
+  { source: "build_validate", target: "git_push" },
   { source: "code_eval", target: "code_gen" },
   { source: "git_push", target: "ci_test" },
   { source: "ci_test", target: "app_spec" },
@@ -167,6 +170,7 @@ const evalPhaseLabels: PhaseLabel[] = [
   { label: "FIX", y: 59, color: "text-orange-400/80" },
   { label: "BUILD", y: 67, color: "text-emerald-400/80" },
   { label: "EVAL", y: 75, color: "text-cyan-400/80" },
+  { label: "VALIDATE", y: 81, color: "text-amber-400/80" },
   { label: "SHIP", y: 86, color: "text-emerald-300/90" },
 ];
 
@@ -180,7 +184,7 @@ const evalCallouts: CalloutDef[] = [];
 
 const brainstormCallouts: CalloutDef[] = [];
 
-const GO_NODES = new Set(["doc_gen", "blueprint", "prompt_strategy", "code_gen", "code_eval", "git_push", "ci_test", "app_spec", "do_build", "do_deploy", "verified"]);
+const GO_NODES = new Set(["doc_gen", "blueprint", "prompt_strategy", "code_gen", "code_eval", "build_validate", "git_push", "ci_test", "app_spec", "do_build", "do_deploy", "verified"]);
 const CONDITIONAL_NODES = new Set(["fix_storm", "scope_down"]);
 const BOTTOM_NODES = new Set([...GO_NODES, ...CONDITIONAL_NODES]);
 
@@ -213,7 +217,7 @@ const EVAL_PARTICLE_ROUTES: ParticleRoute[] = [
   ["decision", "fix_storm", "advocate", "cross_exam"],
   ["decision", "scope_down", "doc_gen"],
   ["decision", "doc_gen", "blueprint", "prompt_strategy", "code_gen", "code_eval"],
-  ["code_eval", "git_push", "ci_test", "app_spec", "do_build", "do_deploy", "verified"],
+  ["code_eval", "build_validate", "git_push", "ci_test", "app_spec", "do_build", "do_deploy", "verified"],
 ];
 
 const BS_PARTICLE_ROUTES: ParticleRoute[] = [
@@ -315,11 +319,11 @@ function getVisibleNodeIds(
   return visible;
 }
 
-export function PipelineViz({ activeNodes = {}, pipeline = "evaluation", className }: PipelineVizProps) {
+export function PipelineViz({ activeNodes = {}, nodeMetadata = {}, pipeline = "evaluation", className }: PipelineVizProps) {
   const nodes = pipeline === "evaluation" ? evalNodes : brainstormNodes;
   const edges = pipeline === "evaluation" ? evalEdges : brainstormEdges;
   const phaseLabels = pipeline === "evaluation" ? evalPhaseLabels : brainstormPhaseLabels;
-  const phaseDividers = pipeline === "evaluation" ? [7.5, 15.5, 24.5, 33.5, 42.5, 50, 56.5, 64, 72, 81] : [28, 67];
+  const phaseDividers = pipeline === "evaluation" ? [7.5, 15.5, 24.5, 33.5, 42.5, 50, 56.5, 64, 72, 79, 83] : [28, 67];
   const callouts = pipeline === "evaluation" ? evalCallouts : brainstormCallouts;
   const getNodeStatus = (id: string): NodeStatus => activeNodes[id] || "idle";
   const visibleNodeIds = getVisibleNodeIds(pipeline, nodes, activeNodes);
@@ -567,6 +571,21 @@ export function PipelineViz({ activeNodes = {}, pipeline = "evaluation", classNa
                     {node.emoji ? <span className="text-[11px] leading-none">{node.emoji}</span> : <span>{getStatusIcon(status)}</span>}
                     <span>{node.label}</span>
                     {status !== "idle" && <span className="ml-0.5">{getStatusIcon(status)}</span>}
+                    {(() => {
+                      const meta = nodeMetadata[node.id];
+                      if (!meta) return null;
+                      if (meta.skipped) return <span className="ml-1 text-[9px] text-slate-400">(skipped)</span>;
+                      if (meta.iteration && meta.maxIterations && meta.iteration > 1) {
+                        return <span className="ml-1 rounded bg-amber-500/25 px-1 text-[9px] font-bold text-amber-300">{meta.iteration}/{meta.maxIterations}</span>;
+                      }
+                      if (meta.repairAttempt && meta.maxRepairs) {
+                        return <span className="ml-1 rounded bg-orange-500/25 px-1 text-[9px] font-bold text-orange-300">fix {meta.repairAttempt}/{meta.maxRepairs}</span>;
+                      }
+                      if (meta.matchRate != null && status === "complete") {
+                        return <span className="ml-1 text-[9px] text-emerald-400">{Math.round(meta.matchRate)}%</span>;
+                      }
+                      return null;
+                    })()}
                   </div>
                 </motion.div>
               );

--- a/web/src/hooks/__tests__/use-pipeline-monitor.test.ts
+++ b/web/src/hooks/__tests__/use-pipeline-monitor.test.ts
@@ -37,5 +37,12 @@ describe("usePipelineMonitor", () => {
     expect(result.current).toHaveProperty("connected");
   });
 
+  it("includes nodeMetadata in returned interface", () => {
+    const { result } = renderHook(() => usePipelineMonitor());
+
+    expect(result.current).toHaveProperty("nodeMetadata");
+    expect(result.current.nodeMetadata).toEqual({});
+  });
+
 });
 

--- a/web/src/hooks/use-pipeline-monitor.ts
+++ b/web/src/hooks/use-pipeline-monitor.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { ActivePipeline, DashboardEvent, PipelineNodeStatus } from "@/types/dashboard";
+import type { ActivePipeline, DashboardEvent, NodeMetadata, PipelineNodeStatus } from "@/types/dashboard";
 
 const AGENT_URL = process.env.NEXT_PUBLIC_AGENT_URL ?? "http://localhost:8080";
 const DASHBOARD_API_URL = AGENT_URL.includes("ondigitalocean.app")
@@ -23,7 +23,7 @@ const NODE_NAME_TO_VIZ_ID: Record<string, string> = {
   prompt_strategist: "prompt_strategy",
   code_generator: "code_gen",
   code_evaluator: "code_eval",
-  deployer: "do_deploy",
+  build_validator: "build_validate",
 };
 
 const AGENT_TO_VIZ_ID: Record<string, string> = {
@@ -52,6 +52,7 @@ const DIRECT_VIZ_NODE_IDS = new Set([
   "score_innovation",
   "score_risk",
   "score_user",
+  "build_validate",
   "git_push",
   "ci_test",
   "app_spec",
@@ -74,6 +75,7 @@ export function usePipelineMonitor() {
   const [activePipelines, setActivePipelines] = useState<ActivePipeline[]>([]);
   const [events, setEvents] = useState<DashboardEvent[]>([]);
   const [nodeStatuses, setNodeStatuses] = useState<Record<string, PipelineNodeStatus>>({});
+  const [nodeMetadata, setNodeMetadata] = useState<Record<string, NodeMetadata>>({});
   const [connected, setConnected] = useState(false);
   const abortRef = useRef<AbortController | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -82,6 +84,13 @@ export function usePipelineMonitor() {
 
   const updateNode = useCallback((vizId: string, status: PipelineNodeStatus) => {
     setNodeStatuses((prev: Record<string, PipelineNodeStatus>) => ({ ...prev, [vizId]: status }));
+  }, []);
+
+  const updateMetadata = useCallback((vizId: string, meta: Partial<NodeMetadata>) => {
+    setNodeMetadata((prev) => ({
+      ...prev,
+      [vizId]: { ...prev[vizId], ...meta },
+    }));
   }, []);
 
   const connectSSE = useCallback(() => {
@@ -128,7 +137,10 @@ export function usePipelineMonitor() {
 
                 if (hadPipelines && nowEmpty) {
                   if (clearTimer.current) clearTimeout(clearTimer.current);
-                  clearTimer.current = setTimeout(() => setNodeStatuses({}), 2000);
+                  clearTimer.current = setTimeout(() => {
+                    setNodeStatuses({});
+                    setNodeMetadata({});
+                  }, 2000);
                 } else if (!nowEmpty && clearTimer.current) {
                   clearTimeout(clearTimer.current);
                   clearTimer.current = null;
@@ -182,7 +194,7 @@ export function usePipelineMonitor() {
 
               if (data.type === "deploy.complete") {
                 updateNode("do_deploy", "complete");
-                updateNode("verified", "complete");
+                // Do not force verified — let the actual verified event determine its status
               }
 
               if (data.type === "brainstorm.agent.insight" && data.agent) {
@@ -210,6 +222,40 @@ export function usePipelineMonitor() {
 
               if (data.type === "code_eval.result") {
                 updateNode("code_eval", data.passed ? "complete" : "active");
+                updateMetadata("code_eval", {
+                  passed: Boolean(data.passed),
+                  iteration: Number(data.iteration) || undefined,
+                  maxIterations: Number(data.max_iterations) || undefined,
+                  matchRate: Number(data.match_rate) || undefined,
+                  completeness: Number(data.completeness) || undefined,
+                  consistency: Number(data.consistency) || undefined,
+                  runnability: Number(data.runnability) || undefined,
+                  experience: Number(data.experience) || undefined,
+                  blockers: Array.isArray(data.blockers) ? data.blockers as string[] : undefined,
+                });
+              }
+
+              if (data.type === "build.node.complete" || data.type === "build.node.error") {
+                updateMetadata("build_validate", {
+                  passed: Boolean(data.passed),
+                  skipped: Boolean(data.skipped),
+                  backendOk: data.backend_ok != null ? Boolean(data.backend_ok) : undefined,
+                  frontendOk: data.frontend_ok != null ? Boolean(data.frontend_ok) : undefined,
+                });
+              }
+
+              if (data.type?.startsWith("deploy.") && data.ci_repair_attempt != null) {
+                updateMetadata("ci_test", {
+                  repairAttempt: Number(data.ci_repair_attempt),
+                  maxRepairs: Number(data.max_retries) || 3,
+                });
+              }
+
+              if (data.type?.startsWith("deploy.") && data.deploy_repair_attempt != null) {
+                updateMetadata("do_build", {
+                  repairAttempt: Number(data.deploy_repair_attempt),
+                  maxRepairs: 3,
+                });
               }
             } catch { }
           }
@@ -220,7 +266,7 @@ export function usePipelineMonitor() {
         reconnectTimer.current = setTimeout(connectSSE, 3_000);
       }
     })();
-  }, [updateNode]);
+  }, [updateNode, updateMetadata]);
 
   const fetchActive = useCallback(async () => {
     try {
@@ -246,6 +292,7 @@ export function usePipelineMonitor() {
     activePipelines,
     events,
     nodeStatuses,
+    nodeMetadata,
     connected,
   };
 }

--- a/web/src/types/dashboard.ts
+++ b/web/src/types/dashboard.ts
@@ -109,6 +109,26 @@ export interface DashboardEvent {
 
 export type PipelineNodeStatus = "idle" | "active" | "complete" | "error";
 
+export interface NodeMetadata {
+  iteration?: number;
+  maxIterations?: number;
+  matchRate?: number;
+  completeness?: number;
+  consistency?: number;
+  runnability?: number;
+  experience?: number;
+  blockers?: string[];
+  passed?: boolean;
+  skipped?: boolean;
+  backendOk?: boolean;
+  frontendOk?: boolean;
+  ciUrl?: string;
+  ciStatus?: string;
+  repairAttempt?: number;
+  maxRepairs?: number;
+  message?: string;
+}
+
 export interface ScoreDistributionBin {
   range: string;
   count: number;


### PR DESCRIPTION
## Summary

- **Fix correctness bugs**: Remove premature `deployer→do_deploy` mapping and `deploy.complete` masking `verified` failures
- **Add build_validate visualization**: New pipeline node between code evaluation and deploy stages with VALIDATE phase label
- **Add SSE events**: `build_validator` emits start/step/complete/error; `code_evaluator` emits scores; `deployer` emits CI/deploy repair loop progress
- **Add metadata store**: `NodeMetadata` interface tracks iteration counts, match rates, repair attempts — displayed as inline retry badges

## Changes

### Backend (agent/)
| File | Change |
|------|--------|
| `nodes/build_validator.py` | Add `config=None` param, `_emit_build_event` helper, 7 event emission points |
| `nodes/code_evaluator.py` | Add `config=None` param, emit `code_eval.result` with scores before return |
| `nodes/deployer.py` | Add `config` to `_ci_repair_loop`, emit CI/deploy repair start/complete events |
| `tests/test_build_validator.py` | +2 tests for event emission and error events |
| `tests/test_code_evaluator.py` | +1 test for `code_eval.result` event emission |

### Frontend (web/)
| File | Change |
|------|--------|
| `types/dashboard.ts` | Add `NodeMetadata` interface (PipelineNodeStatus unchanged) |
| `hooks/use-pipeline-monitor.ts` | Fix deployer mapping, add `build_validator` mapping, metadata store, new event handlers |
| `components/dashboard/pipeline-viz.tsx` | Add `build_validate` node, VALIDATE phase, edges, particle routes, retry badges |
| `components/dashboard/live-monitor.tsx` | Pass `nodeMetadata` to PipelineViz |
| `app/dashboard/page.tsx` | Pass `nodeMetadata` to PipelineViz |
| `hooks/__tests__/use-pipeline-monitor.test.ts` | +1 test for nodeMetadata interface |

## Verification
- ✅ `ruff check .` — all clean
- ✅ `ruff format --check .` — 142 files formatted
- ✅ `npx eslint .` — no errors
- ✅ `npm run build` — compiled successfully
- ✅ `pytest tests/test_build_validator.py tests/test_code_evaluator.py` — 29/29 passed
- ✅ `vitest run use-pipeline-monitor.test.ts` — 3/3 passed

## Architecture Decision
Per Metis/Oracle review: this is a **fidelity pass** (event truth first), not a feature pass. Repair loop edges were intentionally omitted (Oracle: "conceptually inaccurate for deploy repair"). Metadata is stored separately from `PipelineNodeStatus` to maintain type stability.