### PR TITLE
fix: replace Korean UI text with English

### DIFF
--- a/web/src/components/zero-prompt/idea-card.tsx
+++ b/web/src/components/zero-prompt/idea-card.tsx
@@ -53,7 +53,7 @@ export function IdeaCard({ card, onQueueBuild, onPassCard, onDeleteCard, onClick
               className="flex-1 h-8 text-xs"
               onClick={() => onPassCard(card.card_id)}
             >
-              <X className="w-3 h-3 mr-1" /> 패스
+              <X className="w-3 h-3 mr-1" /> Pass
             </Button>
           </div>
         )}
@@ -73,7 +73,7 @@ export function IdeaCard({ card, onQueueBuild, onPassCard, onDeleteCard, onClick
               className="flex-1 h-8 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
               onClick={() => onDeleteCard(card.card_id)}
             >
-              <Trash2 className="w-3 h-3 mr-1" /> 삭제
+              <Trash2 className="w-3 h-3 mr-1" /> Delete
             </Button>
           </div>
         )}

--- a/web/src/components/zero-prompt/kanban-board.tsx
+++ b/web/src/components/zero-prompt/kanban-board.tsx
@@ -13,11 +13,11 @@ interface KanbanBoardProps {
 }
 
 const COLUMNS: { id: string; title: string; statuses: CardStatus[] }[] = [
-  { id: "analyzing", title: "탐색 중", statuses: ["analyzing"] },
-  { id: "go_ready", title: "GO 대기", statuses: ["go_ready"] },
-  { id: "building", title: "빌드 중", statuses: ["build_queued", "building"] },
-  { id: "deployed", title: "배포됨", statuses: ["deployed"] },
-  { id: "nogo", title: "NO-GO / 패스", statuses: ["nogo", "passed", "build_failed"] },
+  { id: "analyzing", title: "Exploring", statuses: ["analyzing"] },
+  { id: "go_ready", title: "GO Ready", statuses: ["go_ready"] },
+  { id: "building", title: "Building", statuses: ["build_queued", "building"] },
+  { id: "deployed", title: "Deployed", statuses: ["deployed"] },
+  { id: "nogo", title: "NO-GO / Passed", statuses: ["nogo", "passed", "build_failed"] },
 ];
 
 export function KanbanBoard({ cards, onQueueBuild, onPassCard, onDeleteCard }: KanbanBoardProps) {

--- a/web/src/components/zero-prompt/status-bar.tsx
+++ b/web/src/components/zero-prompt/status-bar.tsx
@@ -25,7 +25,7 @@ export function StatusBar({ session, isConnected }: StatusBarProps) {
         <CardContent className="p-4 flex items-center justify-between">
           <div>
             <p className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-              <Activity className="w-4 h-4 text-blue-400" /> 탐색 중
+              <Activity className="w-4 h-4 text-blue-400" /> Exploring
             </p>
             <p className="text-2xl font-bold mt-1">{analyzedCount}</p>
           </div>
@@ -38,7 +38,7 @@ export function StatusBar({ session, isConnected }: StatusBarProps) {
       <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
         <CardContent className="p-4">
           <p className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-            <PlayCircle className="w-4 h-4 text-amber-400" /> GO 대기
+            <PlayCircle className="w-4 h-4 text-amber-400" /> GO Ready
           </p>
           <p className="text-2xl font-bold mt-1">{goReadyCount}</p>
         </CardContent>
@@ -47,7 +47,7 @@ export function StatusBar({ session, isConnected }: StatusBarProps) {
       <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
         <CardContent className="p-4">
           <p className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-            <Clock className="w-4 h-4 text-purple-400" /> 빌드 중
+            <Clock className="w-4 h-4 text-purple-400" /> Building
           </p>
           <p className="text-2xl font-bold mt-1">{buildQueueCount}</p>
         </CardContent>
@@ -56,7 +56,7 @@ export function StatusBar({ session, isConnected }: StatusBarProps) {
       <Card className="border-border/50 bg-card/50 backdrop-blur-sm">
         <CardContent className="p-4">
           <p className="text-sm font-medium text-muted-foreground flex items-center gap-2">
-            <CheckCircle className="w-4 h-4 text-emerald-400" /> 배포됨
+            <CheckCircle className="w-4 h-4 text-emerald-400" /> Deployed
           </p>
           <p className="text-2xl font-bold mt-1">{deployedCount}</p>
         </CardContent>


### PR DESCRIPTION
## Summary

웹 UI의 한글 텍스트 11곳을 영문으로 변경.

## Changes (3 files, +11/-11)

| File | Korean → English |
|------|-----------------|
| `kanban-board.tsx` | 탐색 중→Exploring, GO 대기→GO Ready, 빌드 중→Building, 배포됨→Deployed, NO-GO / 패스→NO-GO / Passed |
| `idea-card.tsx` | 패스→Pass, 삭제→Delete |
| `status-bar.tsx` | 탐색 중→Exploring, GO 대기→GO Ready, 빌드 중→Building, 배포됨→Deployed |

Verified: `grep -r '[가-힣]' web/src/ --include='*.tsx' --include='*.ts'` returns 0 matches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * 사용자 인터페이스의 텍스트를 한국어에서 영어로 변경했습니다. 버튼 레이블(패스, 삭제), 칸반 보드 컬럼 제목(탐색 중, GO 대기, 빌드 중, 배포됨, NO-GO / 패스), 상태 표시줄 레이블이 모두 영어로 업데이트되었습니다. 기능과 동작에는 변경사항이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->