### PR TITLE
Phase 4: Production infrastructure hardening

### DIFF
--- a/agent/db/connection.py
+++ b/agent/db/connection.py
@@ -69,7 +69,8 @@ async def get_pool() -> asyncpg.Pool:
 
 
 async def close_pool() -> None:
-    global _pool
+    global _pool, _pool_lock
     if _pool is not None:
         await _pool.close()
         _pool = None
+        _pool_lock = None

--- a/agent/db/connection.py
+++ b/agent/db/connection.py
@@ -4,8 +4,9 @@ import os
 import asyncpg
 
 _pool: asyncpg.Pool | None = None
-_DEFAULT_POOL_MIN_SIZE = 1
-_DEFAULT_POOL_MAX_SIZE = 1
+_pool_lock: asyncio.Lock | None = None
+_DEFAULT_POOL_MIN_SIZE = 2
+_DEFAULT_POOL_MAX_SIZE = 10
 _DEFAULT_POOL_RETRIES = 5
 _DEFAULT_POOL_RETRY_DELAY = 2.0
 
@@ -31,8 +32,14 @@ def _float_env(name: str, default: float, minimum: float = 0.0) -> float:
 
 
 async def get_pool() -> asyncpg.Pool:
-    global _pool
-    if _pool is None:
+    global _pool, _pool_lock
+    if _pool_lock is None:
+        _pool_lock = asyncio.Lock()
+    if _pool is not None:
+        return _pool
+    async with _pool_lock:
+        if _pool is not None:
+            return _pool
         database_url = os.environ.get("DATABASE_URL", "")
         if not database_url:
             raise RuntimeError("DATABASE_URL environment variable is required")

--- a/agent/db/zp_store.py
+++ b/agent/db/zp_store.py
@@ -190,10 +190,10 @@ async def update_card(card_id: str, **fields: object) -> None:
     values = []
     for i, (k, v) in enumerate(fields.items(), 1):
         if k in _JSONB_COLUMNS:
-            sets.append(f"{k} = ${i}::jsonb")
+            sets.append(f'"{k}" = ${i}::jsonb')
             values.append(json.dumps(v) if not isinstance(v, str) else v)
         else:
-            sets.append(f"{k} = ${i}")
+            sets.append(f'"{k}" = ${i}')
             values.append(v)
     values.append(card_id)
     async with pool.acquire() as conn:

--- a/agent/db/zp_store.py
+++ b/agent/db/zp_store.py
@@ -167,14 +167,29 @@ async def add_card(session_id: str, card_id: str, video_id: str, title: str = ""
     return {"card_id": card_id, "video_id": video_id, "title": title, "status": "analyzing"}
 
 
+_ALLOWED_CARD_COLUMNS = frozenset({
+    "status", "score", "domain", "reason", "reason_code",
+    "score_breakdown", "papers_found", "competitors_found",
+    "saturation", "novelty_boost", "video_summary", "insights",
+    "mvp_proposal", "build_step", "analysis_step", "repo_url",
+    "live_url", "thread_id", "title", "video_id",
+    "build_events", "build_phase", "build_node",
+})
+
+_JSONB_COLUMNS = frozenset({"insights", "mvp_proposal", "score_breakdown", "build_events"})
+
+
 async def update_card(card_id: str, **fields: object) -> None:
     if not fields:
         return
+    invalid = set(fields.keys()) - _ALLOWED_CARD_COLUMNS
+    if invalid:
+        raise ValueError(f"Disallowed column names: {invalid}")
     pool = await get_pool()
     sets = []
     values = []
     for i, (k, v) in enumerate(fields.items(), 1):
-        if k in ("insights", "mvp_proposal", "score_breakdown"):
+        if k in _JSONB_COLUMNS:
             sets.append(f"{k} = ${i}::jsonb")
             values.append(json.dumps(v) if not isinstance(v, str) else v)
         else:

--- a/agent/run_server.py
+++ b/agent/run_server.py
@@ -24,8 +24,11 @@ if __name__ == "__main__":
     multiprocessing.freeze_support()
     uvicorn.run(
         "agent.server:app",
-        host="0.0.0.0",
-        port=8080,
+        host=os.environ.get("UVICORN_HOST", "0.0.0.0"),
+        port=int(os.environ.get("PORT", "8080")),
         workers=_read_worker_count(),
         timeout_keep_alive=300,
+        server_header=False,
+        proxy_headers=True,
+        forwarded_allow_ips=os.environ.get("FORWARDED_ALLOW_IPS", "*"),
     )

--- a/agent/run_server.py
+++ b/agent/run_server.py
@@ -30,5 +30,5 @@ if __name__ == "__main__":
         timeout_keep_alive=300,
         server_header=False,
         proxy_headers=True,
-        forwarded_allow_ips=os.environ.get("FORWARDED_ALLOW_IPS", "*"),
+        forwarded_allow_ips=os.environ.get("FORWARDED_ALLOW_IPS", "127.0.0.1"),
     )

--- a/agent/server.py
+++ b/agent/server.py
@@ -882,12 +882,7 @@ async def put_test_brainstorm(brainstorm_id: str, body: dict):
 @app.get("/health")
 @app.get("/")
 async def health():
-    return {
-        "status": "ok",
-        "provider": "do-app-platform-gateway",
-        "adk_url_configured": bool(_configured_adk_url()),
-        "adk_auth_mode": _configured_adk_auth_mode(),
-    }
+    return {"status": "ok"}
 
 
 @app.get("/api/cost-estimate")
@@ -966,9 +961,14 @@ async def dashboard_active():
     return list(_active_pipelines.values())
 
 
+_MAX_DASHBOARD_SSE = int(os.getenv("MAX_DASHBOARD_SSE", "50"))
+
+
 @app.get("/dashboard/events")
 @app.get("/events")
 async def dashboard_events():
+    if len(_dashboard_queues) >= _MAX_DASHBOARD_SSE:
+        raise HTTPException(status_code=503, detail="Too many SSE connections")
     queue: asyncio.Queue = asyncio.Queue(maxsize=256)
     _dashboard_queues.append(queue)
 

--- a/agent/tests/test_server_routes.py
+++ b/agent/tests/test_server_routes.py
@@ -15,9 +15,7 @@ async def test_health(app_client):
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
-    assert "provider" in body
-    assert "adk_url_configured" in body
-    assert "adk_auth_mode" in body
+    assert len(body) == 1  # Only status field — no internal config disclosure
 
 
 @pytest.mark.asyncio

--- a/agent/tools/digitalocean.py
+++ b/agent/tools/digitalocean.py
@@ -250,14 +250,18 @@ def build_app_spec(
         db_url = db_url.replace("postgresql://", "postgresql+psycopg://", 1)
 
     envs = []
-    if db_url:
-        envs.append({"key": "DATABASE_URL", "value": db_url, "scope": "RUN_TIME", "type": "SECRET"})
-        envs.append({"key": "POSTGRES_URL", "value": db_url, "scope": "RUN_TIME", "type": "SECRET"})
-    inference_key = os.getenv("GRADIENT_MODEL_ACCESS_KEY", "") or os.getenv("DIGITALOCEAN_INFERENCE_KEY", "")
-    if inference_key:
-        envs.append({"key": "GRADIENT_MODEL_ACCESS_KEY", "value": inference_key, "scope": "RUN_TIME", "type": "SECRET"})
+    # Use separate credentials for generated apps — NEVER share the host's own DB.
+    generated_db_url = os.getenv("GENERATED_APP_DATABASE_URL", db_url)
+    if generated_db_url:
+        envs.append({"key": "DATABASE_URL", "value": generated_db_url, "scope": "RUN_TIME", "type": "SECRET"})
+        envs.append({"key": "POSTGRES_URL", "value": generated_db_url, "scope": "RUN_TIME", "type": "SECRET"})
+    generated_inference_key = os.getenv("GENERATED_APP_INFERENCE_KEY", "") or os.getenv(
+        "GRADIENT_MODEL_ACCESS_KEY", ""
+    ) or os.getenv("DIGITALOCEAN_INFERENCE_KEY", "")
+    if generated_inference_key:
+        envs.append({"key": "GRADIENT_MODEL_ACCESS_KEY", "value": generated_inference_key, "scope": "RUN_TIME", "type": "SECRET"})
         envs.append(
-            {"key": "DIGITALOCEAN_INFERENCE_KEY", "value": inference_key, "scope": "RUN_TIME", "type": "SECRET"}
+            {"key": "DIGITALOCEAN_INFERENCE_KEY", "value": generated_inference_key, "scope": "RUN_TIME", "type": "SECRET"}
         )
     envs.append({"key": "DO_INFERENCE_MODEL", "value": "anthropic-claude-4.6-sonnet", "scope": "RUN_TIME"})
 

--- a/agent/tools/digitalocean.py
+++ b/agent/tools/digitalocean.py
@@ -251,13 +251,11 @@ def build_app_spec(
 
     envs = []
     # Use separate credentials for generated apps — NEVER share the host's own DB.
-    generated_db_url = os.getenv("GENERATED_APP_DATABASE_URL", db_url)
+    generated_db_url = os.getenv("GENERATED_APP_DATABASE_URL", "")
     if generated_db_url:
         envs.append({"key": "DATABASE_URL", "value": generated_db_url, "scope": "RUN_TIME", "type": "SECRET"})
         envs.append({"key": "POSTGRES_URL", "value": generated_db_url, "scope": "RUN_TIME", "type": "SECRET"})
-    generated_inference_key = os.getenv("GENERATED_APP_INFERENCE_KEY", "") or os.getenv(
-        "GRADIENT_MODEL_ACCESS_KEY", ""
-    ) or os.getenv("DIGITALOCEAN_INFERENCE_KEY", "")
+    generated_inference_key = os.getenv("GENERATED_APP_INFERENCE_KEY", "")
     if generated_inference_key:
         envs.append({"key": "GRADIENT_MODEL_ACCESS_KEY", "value": generated_inference_key, "scope": "RUN_TIME", "type": "SECRET"})
         envs.append(


### PR DESCRIPTION
## Summary
1. **db/connection.py**: `asyncio.Lock` to prevent duplicate pool creation; pool default 1/1 → 2/10
2. **db/zp_store.py**: SQL column allowlist (`_ALLOWED_CARD_COLUMNS`) to prevent injection
3. **tools/digitalocean.py**: separate `GENERATED_APP_*` credentials for deployed apps
4. **run_server.py**: `server_header=False`, `proxy_headers=True`, configurable host/port
5. **server.py**: health → `{"status":"ok"}` only; SSE connection limit (max 50)

## Changes
- **6 files changed**, +50 -23 lines

## Test plan
- [x] 76 affected tests pass (server routes, deployer, ZP routes)
- [x] Health test updated to verify minimal response
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)